### PR TITLE
Code generation fixes

### DIFF
--- a/mcfc/codegeneration.py
+++ b/mcfc/codegeneration.py
@@ -559,10 +559,13 @@ class Array(Type):
     def __init__(self, base, extents):
         Type.__init__(self)
         self._base = base
-        self._extents = extents if isinstance(extents,list) else [extents]
+        try:
+            self._extents = list(extents)
+        except TypeError:
+            self._extents = [extents]
 
     def unparse_internal(self):
-        return self._base.unparse_internal()
+        return self._base.unparse()
 
     def unparse_post(self):
         code = ''

--- a/mcfc/codegeneration.py
+++ b/mcfc/codegeneration.py
@@ -497,9 +497,11 @@ class Include(BackendASTNode):
 
 class Type:
 
-    def __init__(self):
+    def __init__(self, isConst = False, isCudaShared = False):
         # FIXME need the order of modifiers be enforced / preserved?
         self._modifier = set()
+        self.setConst(isConst)
+        self.setCudaShared(isCudaShared)
 
     def unparse(self):
         modifier = self.unparse_modifier()

--- a/mcfc/codegeneration.py
+++ b/mcfc/codegeneration.py
@@ -129,10 +129,7 @@ class ForLoop(BackendASTNode):
         self._init = init
         self._test = test
         self._inc = inc
-        if body is None:
-            self._body = Scope()
-        else:
-            self._body = body
+        self._body = body or Scope()
 
     def append(self, statement):
         self._body.append(statement)
@@ -147,10 +144,9 @@ class ForLoop(BackendASTNode):
         init = self._init.unparse()
         test = self._test.unparse(False)
         inc = self._inc.unparse()
+        header = 'for(%s; %s; %s)\n' % (init, test, inc)
         body = self._body.unparse()
-        code = 'for(%s; %s; %s)\n' % (init, test, inc)
-        code = code + body
-        return code
+        return header + body
 
     __str__ = unparse
 
@@ -408,7 +404,7 @@ class PlusAssignmentOp(BinaryOp):
 
 class InitialisationOp(AssignmentOp):
 
-    def unparse(self):
+    def unparse(self, bracketed=False):
         lhs = self._lhs.unparse_declaration()
         rhs = self._rhs.unparse()
         return '%s %s %s' % (lhs, self._op, rhs)

--- a/mcfc/codegeneration.py
+++ b/mcfc/codegeneration.py
@@ -571,10 +571,14 @@ class Array(Type):
     def __init__(self, base, extents):
         Type.__init__(self)
         self._base = base
+        # Assuming extents is an iterable
         try:
             self._extents = list(extents)
+        # Otherwise it is a scalar
         except TypeError:
             self._extents = [extents]
+        # Convert ints to literals
+        self._extents = [Literal(x) if isinstance(x,int) else x for x in self._extents]
 
     def unparse_internal(self):
         return self._base.unparse()

--- a/mcfc/codegeneration.py
+++ b/mcfc/codegeneration.py
@@ -392,14 +392,10 @@ class PlusAssignmentOp(BinaryOp):
 
 class InitialisationOp(AssignmentOp):
 
-    def __init__(self, lhs, rhs):
-        AssignmentOp.__init__(self, lhs, rhs)
-
     def unparse(self):
-        t = self._lhs._t.unparse()
-        assignment = AssignmentOp.unparse(self, False)
-        code = '%s %s' % (t, assignment)
-        return code
+        lhs = self._lhs.unparse_declaration()
+        rhs = self._rhs.unparse()
+        return '%s %s %s' % (lhs, self._op, rhs)
 
     __str__ = unparse
 

--- a/mcfc/codegeneration.py
+++ b/mcfc/codegeneration.py
@@ -21,6 +21,8 @@
 """codegeneration.py - provides tools to build a C++/CUDA/OpenCL ASTs and
 unparse it to a file."""
 
+import numpy
+
 class BackendASTNode:
     pass
 
@@ -599,6 +601,19 @@ def getScopeFromNest(nest, depth):
         loop = body.find(lambda x: isinstance(x, ForLoop))
         body = loop.body()
     return body
+
+def buildConstArrayInitializer(arrayName, values):
+    "Build an initializer for a constant array from a given NumPy array."
+
+    # Make input a NumPy array (and fail it it doesn't work)
+    values = numpy.asarray(values, numpy.float)
+
+    # Create a const array of appropriate shape
+    var = Variable(arrayName, Array(Real(isConst=True), map(Literal, values.shape)))
+    # Replace all [ delimiters by { in string representation of the array
+    arrStr = numpy.array2string(values, separator=',')
+    data = UnparsedCode(arrStr.replace('[','{ ').replace(']',' }'))
+    return InitialisationOp(var, data)
 
 # Unparser-specific functions
 

--- a/mcfc/codegeneration.py
+++ b/mcfc/codegeneration.py
@@ -109,6 +109,17 @@ class Literal(BackendASTNode):
 
     __str__ = unparse
 
+class InitialiserList(BackendASTNode):
+
+    def __init__(self, array):
+        # Make input a NumPy array (and fail it it doesn't work)
+        self._array = numpy.asarray(array, numpy.float)
+
+    def unparse(self):
+        arrStr = numpy.array2string(self._array, separator=',')
+        # Replace all [ delimiters by { in string representation of the array
+        return arrStr.replace('[','{ ').replace(']',' }')
+
 class ForLoop(BackendASTNode):
 
     def __init__(self, init, test, inc, body=None):
@@ -610,10 +621,7 @@ def buildConstArrayInitializer(arrayName, values):
 
     # Create a const array of appropriate shape
     var = Variable(arrayName, Array(Real(isConst=True), map(Literal, values.shape)))
-    # Replace all [ delimiters by { in string representation of the array
-    arrStr = numpy.array2string(values, separator=',')
-    data = UnparsedCode(arrStr.replace('[','{ ').replace(']',' }'))
-    return InitialisationOp(var, data)
+    return InitialisationOp(var, InitialiserList(values))
 
 # Unparser-specific functions
 

--- a/mcfc/codegeneration.py
+++ b/mcfc/codegeneration.py
@@ -498,7 +498,8 @@ class Include(BackendASTNode):
 class Type:
 
     def __init__(self):
-        self._modifier = ''
+        # FIXME need the order of modifiers be enforced / preserved?
+        self._modifier = set()
 
     def unparse(self):
         modifier = self.unparse_modifier()
@@ -506,14 +507,20 @@ class Type:
         code = '%s%s' % (modifier, internal)
         return code
 
-    def setCudaShared(self, isCudaShared):
-        if isCudaShared:
-            self._modifier = '__shared__ '
+    def _setModifier(self, setModifier, modifier):
+        if setModifier:
+            self._modifier.add(modifier)
         else:
-            self._modifier = ''
+            self._modifier.discard(modifier)
+
+    def setConst(self, isConst):
+        self._setModifier(isConst, 'const ')
+
+    def setCudaShared(self, isCudaShared):
+        self._setModifier(isCudaShared, '__shared__ ')
 
     def unparse_modifier(self):
-        return self._modifier
+        return ''.join(self._modifier)
 
     def unparse_post(self):
         return ''

--- a/mcfc/cudaexpression.py
+++ b/mcfc/cudaexpression.py
@@ -20,6 +20,11 @@
 from expression import *
 from cudaparameters import numElements
 
+# Variables
+
+threadCount = Variable("THREAD_COUNT")
+threadId = Variable("THREAD_ID")
+
 # The ElementIndex is here and not form.py because not all backends need
 # an element index (e.g. OP2).
 
@@ -30,6 +35,15 @@ class ElementIndex:
 
     def name(self):
         return "i_ele"
+
+def buildElementLoop():
+    indVarName = ElementIndex().name()
+    var = Variable(indVarName, Integer())
+    init = InitialisationOp(var, threadId)
+    test = LessThanOp(var, numElements)
+    inc = PlusAssignmentOp(var, threadCount)
+    ast = ForLoop(init, test, inc)
+    return ast
 
 def buildSubscript(variable, indices):
     """Given a list of indices, return an AST that computes

--- a/mcfc/cudaform.py
+++ b/mcfc/cudaform.py
@@ -21,12 +21,7 @@
 # MCFC libs
 from form import *
 from cudaparameters import CudaKernelParameterGenerator, numElements, statutoryParameters
-from cudaexpression import CudaExpressionBuilder, CudaQuadratureExpressionBuilder, ElementIndex
-
-# Variables
-
-threadCount = Variable("THREAD_COUNT")
-threadId = Variable("THREAD_ID")
+from cudaexpression import CudaExpressionBuilder, CudaQuadratureExpressionBuilder, buildElementLoop
 
 class CudaFormBackend(FormBackend):
 
@@ -152,7 +147,7 @@ class CudaFormBackend(FormBackend):
         integrand = form.integrals()[0].integrand()
 
         # The element loop is the outermost loop
-        loop = self.buildElementLoop()
+        loop = buildElementLoop()
         outerLoop = loop
 
         # Build the loop over the first rank, which always exists
@@ -190,14 +185,5 @@ class CudaFormBackend(FormBackend):
         # Hand back the outer loop, so it can be inserted into some
         # scope.
         return outerLoop
-
-    def buildElementLoop(self):
-        indVarName = ElementIndex().name()
-        var = Variable(indVarName, Integer())
-        init = InitialisationOp(var, threadId)
-        test = LessThanOp(var, numElements)
-        inc = PlusAssignmentOp(var, threadCount)
-        ast = ForLoop(init, test, inc)
-        return ast
 
 # vim:sw=4:ts=4:sts=4:et

--- a/mcfc/cudaform.py
+++ b/mcfc/cudaform.py
@@ -20,7 +20,7 @@
 
 # MCFC libs
 from form import *
-from cudaparameters import generateKernelParameters, numElements, statutoryParameters
+from cudaparameters import CudaKernelParameterGenerator, numElements, statutoryParameters
 from cudaexpression import CudaExpressionBuilder, CudaQuadratureExpressionBuilder, ElementIndex
 
 # Variables
@@ -45,7 +45,7 @@ class CudaFormBackend(FormBackend):
         rank = form_data.rank
         
         # Get parameter list for kernel declaration.
-        formalParameters, actualParameters = generateKernelParameters(integrand, form)
+        formalParameters, actualParameters = self._buildKernelParameters(integrand, form)
         # Attach list of formal and actual kernel parameters to form data
         form.form_data().formalParameters = formalParameters
         form.form_data().actualParameters = actualParameters
@@ -84,6 +84,10 @@ class CudaFormBackend(FormBackend):
         # Make this a Cuda kernel.
         kernel.setCudaKernel(True)
         return kernel
+
+    def _buildKernelParameters(self, tree, form):
+        KPG = CudaKernelParameterGenerator()
+        return KPG.generate(tree, form, statutoryParameters)
 
     def buildCoeffQuadDeclarations(self, form):
         # The FormBackend's list of variables to declare is

--- a/mcfc/cudaparameters.py
+++ b/mcfc/cudaparameters.py
@@ -39,8 +39,4 @@ class CudaKernelParameterGenerator(KernelParameterGenerator):
         name = form.buildSpatialDerivativeName(argDeriv)
         return Variable(name, Pointer(Real()))
 
-def generateKernelParameters(tree, form):
-    KPG = CudaKernelParameterGenerator()
-    return KPG.generate(tree, form, statutoryParameters)
-
 # vim:sw=4:ts=4:sts=4:et

--- a/mcfc/form.py
+++ b/mcfc/form.py
@@ -237,6 +237,9 @@ class DimIndex(CodeIndex):
 
 # Name builders
 
+def safe_shortstr(name):
+    return name[:name.find('(')]
+
 def buildArgumentName(tree):
     element = tree.element()
     if element.num_sub_elements() is not 0:
@@ -247,8 +250,7 @@ def buildArgumentName(tree):
             sub_elements = element.sub_elements()
             element = sub_elements[0]
         
-    name = element.shortstr()
-    return name[:name.find('(')]
+    return safe_shortstr(element.shortstr())
 
 def buildSpatialDerivativeName(tree):
     operand = tree.operands()[0]

--- a/mcfc/form.py
+++ b/mcfc/form.py
@@ -111,6 +111,9 @@ class FormBackend:
     def compile(self, form):
         raise NotImplementedError("You're supposed to implement compile()!")
 
+    def _buildKernelParameters(self, tree, form):
+        raise NotImplementedError("You're supposed to implement _buildKernelParameters()!")
+
 class CoefficientUseFinder(Transformer):
     """Finds the nodes that 'use' a coefficient. This is either a Coefficient
     itself, or a SpatialDerivative that has a Coefficient as its operand"""

--- a/mcfc/op2form.py
+++ b/mcfc/op2form.py
@@ -20,7 +20,7 @@
 
 # MCFC libs
 from form import *
-from op2parameters import generateKernelParameters
+from op2parameters import Op2KernelParameterGenerator, _buildArrayParameter
 from op2expression import Op2ExpressionBuilder, Op2QuadratureExpressionBuilder
 
 class Op2FormBackend(FormBackend):
@@ -75,6 +75,17 @@ class Op2FormBackend(FormBackend):
                 loopNest.prepend(decl)
         
         return kernel
+
+    def _buildKernelParameters(self, tree, form):
+        KPG = Op2KernelParameterGenerator(self)
+
+        detwei = _buildArrayParameter("detwei", KPG.expBuilder.subscript_detwei())
+        timestep = Variable("dt", Real() )
+        localTensor = _buildArrayParameter("localTensor", KPG.expBuilder.subscript_LocalTensor(form))
+
+        statutoryParameters = [ localTensor, timestep, detwei ]
+
+        return KPG.generate(tree, form, statutoryParameters)
 
     def buildQuadratureLoopNest(self, form):
         
@@ -166,7 +177,7 @@ class Op2FormBackend(FormBackend):
         return outerLoop
 
     def buildParameterList(self, tree, form):
-        formalParameters, _ = generateKernelParameters(tree, form, self)
+        formalParameters, _ = self._buildKernelParameters(tree, form)
         return formalParameters
 
 # vim:sw=4:ts=4:sts=4:et

--- a/mcfc/op2parameters.py
+++ b/mcfc/op2parameters.py
@@ -48,15 +48,4 @@ class Op2KernelParameterGenerator(KernelParameterGenerator):
 def _buildArrayParameter(name, indices):
     return Variable(name, Array(Real(), [i.extent() for i in indices]))
 
-def generateKernelParameters(tree, form, op2form):
-    KPG = Op2KernelParameterGenerator(op2form)
-
-    detwei = _buildArrayParameter("detwei", KPG.expBuilder.subscript_detwei())
-    timestep = Variable("dt", Real() )
-    localTensor = _buildArrayParameter("localTensor", KPG.expBuilder.subscript_LocalTensor(form))
-
-    statutoryParameters = [ localTensor, timestep, detwei ]
-
-    return KPG.generate(tree, form, statutoryParameters)
-
 # vim:sw=4:ts=4:sts=4:et


### PR DESCRIPTION
- helper function to generate an intialiser for a constant C array from a given NumPy array
- `Type` can have a set of modifiers, add `const` modifier
- fix `InitialisationOp` for use with `Array`
- `Array` can take any iterable or scalar for its extents, integers are converted to `Literal`s
- minor enhancements to `ForLoop`
