### PR TITLE
Local vector assembly

### DIFF
--- a/mcfc/codegeneration.py
+++ b/mcfc/codegeneration.py
@@ -582,9 +582,6 @@ class Array(Type):
     def unparse_internal(self):
         return self._base.unparse()
 
-    def unparse_declaration(self):
-        return '%s%s' % (self.unparse_internal(), self.unparse_post())
-
     def unparse_post(self):
         code = ''
         for extent in self._extents:

--- a/mcfc/cudaexpression.py
+++ b/mcfc/cudaexpression.py
@@ -68,12 +68,23 @@ def buildSubscript(variable, indices):
     
     return Subscript(variable, offset)
 
+def buildMultiArraySubscript(variable, indices):
+    
+    indexList = []
+    for i in indices:
+        variable = Subscript(variable, Variable(i.name()))
+
+    return variable
+
 # Expression builders
 
 class CudaExpressionBuilder(ExpressionBuilder):
 
     def buildSubscript(self, variable, indices):
         return buildSubscript(variable, indices)
+
+    def buildMultiArraySubscript(self, variable, indices):
+        return buildMultiArraySubscript(variable, indices)
 
     def subscript(self, tree, depth=None):
         meth = getattr(self, "subscript_"+tree.__class__.__name__)
@@ -85,7 +96,11 @@ class CudaExpressionBuilder(ExpressionBuilder):
     def subscript_Argument(self, tree):
         # Build the subscript based on the argument count
         count = tree.count()
-        indices = [self._form.buildBasisIndex(count), self._form.buildGaussIndex()]
+        indices = []
+        for t in self._indexStack:
+            for i in t:
+                indices.append(self._form.buildDimIndex(i.count()))
+        indices = indices + [self._form.buildBasisIndex(count), self._form.buildGaussIndex()]
         return indices
 
     def subscript_SpatialDerivative(self,tree,depth):

--- a/mcfc/cudaexpression.py
+++ b/mcfc/cudaexpression.py
@@ -69,7 +69,10 @@ def buildSubscript(variable, indices):
     return Subscript(variable, offset)
 
 def buildMultiArraySubscript(variable, indices):
-    
+    """Given a list of indices, return an AST of the variable
+    subscripted by the indices as if it were a multidimensional
+    array."""
+
     indexList = []
     for i in indices:
         variable = Subscript(variable, Variable(i.name()))

--- a/mcfc/cudaform.py
+++ b/mcfc/cudaform.py
@@ -88,6 +88,9 @@ class CudaFormBackend(FormBackend):
         KPG = CudaKernelParameterGenerator()
         return KPG.generate(tree, form, statutoryParameters)
 
+    # When using a basis that is a tensor product of the scalar basis, we need
+    # to create an array that holds the tensor product. This function generates
+    # the code to declare and initialise that array.
     def _buildBasisTensors(self, form_data):
         gp = self.numGaussPoints
         nn = self.numNodesPerEle
@@ -195,9 +198,11 @@ class CudaFormBackend(FormBackend):
         # Use the element from the first argument, which should be the TestFunction
         arg = form.form_data().arguments[0]
         e = arg.element()
-
         return e.cell().geometric_dimension()
 
+    # This function provides a simple calculation of the number of basis
+    # functions per element. This works for the tensor product of a scalar basis
+    # only.
     def _numBasisFunctions(self, form):
         form_data = form.form_data()
         elementRank = self._elementRank(form)

--- a/mcfc/expression.py
+++ b/mcfc/expression.py
@@ -54,6 +54,9 @@ class ExpressionBuilder(Transformer):
     def component_tensor(self, tree, *ops):
         pass
 
+    # When entering an index, we need to memorise the indices that are attached 
+    # to it before descending into the sub-tree. The sub-tree handlers can make
+    # use of these memorised indices in their code generation.
     def indexed(self, tree):
         o, i = tree.operands()
         self._indexStack.push(self.visit(i))
@@ -111,16 +114,13 @@ class ExpressionBuilder(Transformer):
         indices = self.subscript(tree)
         
         if isinstance(e, FiniteElement):
-            name = buildArgumentName(tree)
-            base = Variable(name)
+            base = Variable(buildArgumentName(tree))
             argExpr = self.buildSubscript(base, indices)
         elif isinstance(e, VectorElement):
-            name = buildVectorArgumentName(tree)
-            base = Variable(name)
+            base = Variable(buildVectorArgumentName(tree))
             argExpr = self.buildMultiArraySubscript(base, indices)
         else:
-            name = buildTensorArgumentName(tree)
-            base = Variable(name)
+            base = Variable(buildTensorArgumentName(tree))
             argExpr = self.buildMultiArraySubscript(base, indices)
 
         self._exprStack.append(argExpr)

--- a/mcfc/form.py
+++ b/mcfc/form.py
@@ -277,6 +277,18 @@ def buildCoefficientQuadName(tree):
     name = 'c_q%d' %(count)
     return name
 
+def buildVectorArgumentName(tree):
+    return buildArgumentName(tree) + "_v"
+
+def buildVectorSpatialDerivativeName(tree):
+    return buildSpatialDerivativeName(tree) + "_v"
+
+def buildTensorArgumentName(tree):
+    return buildArgumentName(tree) + "_t"
+
+def buildTensorSpatialDerivativeName(tree):
+    return buildSpatialDerivativeName(tree) + "_t"
+
 # Variables used globally
 
 detwei = Variable("detwei", Pointer(Real()) )

--- a/mcfc/op2expression.py
+++ b/mcfc/op2expression.py
@@ -37,6 +37,9 @@ class Op2ExpressionBuilder(ExpressionBuilder):
     def buildSubscript(self, variable, indices):
         return buildSubscript(variable, indices)
 
+    def buildMultiArraySubscript(self, variable, indices):
+        return buildSubscript(variable, indices)
+
     def subscript(self, tree, depth=None):
         meth = getattr(self, "subscript_"+tree.__class__.__name__)
         if depth is None:

--- a/tests/expected/cuda/identity-vector.cu
+++ b/tests/expected/cuda/identity-vector.cu
@@ -13,6 +13,7 @@ int Velocity_colm_size;
 
 __global__ void A(double* localTensor, int n_ele, double dt, double* detwei, double* CG1)
 {
+  double CG1_v[2][6][6] = { { { CG1[0], CG1[6], CG1[12], 0.0, 0.0, 0.0 }, { CG1[1], CG1[7], CG1[13], 0.0, 0.0, 0.0 }, { CG1[2], CG1[8], CG1[14], 0.0, 0.0, 0.0 }, { CG1[3], CG1[9], CG1[15], 0.0, 0.0, 0.0 }, { CG1[4], CG1[10], CG1[16], 0.0, 0.0, 0.0 }, { CG1[5], CG1[11], CG1[17], 0.0, 0.0, 0.0 } }, { { 0.0, 0.0, 0.0, CG1[0], CG1[6], CG1[12] }, { 0.0, 0.0, 0.0, CG1[1], CG1[7], CG1[13] }, { 0.0, 0.0, 0.0, CG1[2], CG1[8], CG1[14] }, { 0.0, 0.0, 0.0, CG1[3], CG1[9], CG1[15] }, { 0.0, 0.0, 0.0, CG1[4], CG1[10], CG1[16] }, { 0.0, 0.0, 0.0, CG1[5], CG1[11], CG1[17] } } };
   for(int i_ele = THREAD_ID; i_ele < n_ele; i_ele += THREAD_COUNT)
   {
     for(int i_r_0 = 0; i_r_0 < 6; i_r_0++)
@@ -34,6 +35,7 @@ __global__ void A(double* localTensor, int n_ele, double dt, double* detwei, dou
 
 __global__ void RHS(double* localTensor, int n_ele, double dt, double* detwei, double* c0, double* CG1)
 {
+  double CG1_v[2][6][6] = { { { CG1[0], CG1[6], CG1[12], 0.0, 0.0, 0.0 }, { CG1[1], CG1[7], CG1[13], 0.0, 0.0, 0.0 }, { CG1[2], CG1[8], CG1[14], 0.0, 0.0, 0.0 }, { CG1[3], CG1[9], CG1[15], 0.0, 0.0, 0.0 }, { CG1[4], CG1[10], CG1[16], 0.0, 0.0, 0.0 }, { CG1[5], CG1[11], CG1[17], 0.0, 0.0, 0.0 } }, { { 0.0, 0.0, 0.0, CG1[0], CG1[6], CG1[12] }, { 0.0, 0.0, 0.0, CG1[1], CG1[7], CG1[13] }, { 0.0, 0.0, 0.0, CG1[2], CG1[8], CG1[14] }, { 0.0, 0.0, 0.0, CG1[3], CG1[9], CG1[15] }, { 0.0, 0.0, 0.0, CG1[4], CG1[10], CG1[16] }, { 0.0, 0.0, 0.0, CG1[5], CG1[11], CG1[17] } } };
   for(int i_ele = THREAD_ID; i_ele < n_ele; i_ele += THREAD_COUNT)
   {
     double c_q0[12];

--- a/tests/expected/cuda/identity-vector.cu
+++ b/tests/expected/cuda/identity-vector.cu
@@ -15,9 +15,9 @@ __global__ void A(double* localTensor, int n_ele, double dt, double* detwei, dou
 {
   for(int i_ele = THREAD_ID; i_ele < n_ele; i_ele += THREAD_COUNT)
   {
-    for(int i_r_0 = 0; i_r_0 < 3; i_r_0++)
+    for(int i_r_0 = 0; i_r_0 < 6; i_r_0++)
     {
-      for(int i_r_1 = 0; i_r_1 < 3; i_r_1++)
+      for(int i_r_1 = 0; i_r_1 < 6; i_r_1++)
       {
         localTensor[((i_ele + n_ele * i_r_0) + 3 * n_ele * i_r_1)] = 0.0;
         for(int i_g = 0; i_g < 6; i_g++)
@@ -48,7 +48,7 @@ __global__ void RHS(double* localTensor, int n_ele, double dt, double* detwei, d
         };
       };
     };
-    for(int i_r_0 = 0; i_r_0 < 3; i_r_0++)
+    for(int i_r_0 = 0; i_r_0 < 6; i_r_0++)
     {
       localTensor[(i_ele + n_ele * i_r_0)] = 0.0;
       for(int i_g = 0; i_g < 6; i_g++)

--- a/tests/expected/cuda/identity-vector.cu
+++ b/tests/expected/cuda/identity-vector.cu
@@ -25,7 +25,7 @@ __global__ void A(double* localTensor, int n_ele, double dt, double* detwei, dou
         {
           for(int i_d_0 = 0; i_d_0 < 2; i_d_0++)
           {
-            localTensor[((i_ele + n_ele * i_r_0) + 3 * n_ele * i_r_1)] += CG1[(i_r_0 + 3 * i_g)] * CG1[(i_r_1 + 3 * i_g)] * detwei[(i_ele + n_ele * i_g)];
+            localTensor[((i_ele + n_ele * i_r_0) + 3 * n_ele * i_r_1)] += CG1_v[i_d_0][i_r_0][i_g] * CG1_v[i_d_0][i_r_1][i_g] * detwei[(i_ele + n_ele * i_g)];
           };
         };
       };
@@ -57,7 +57,7 @@ __global__ void RHS(double* localTensor, int n_ele, double dt, double* detwei, d
       {
         for(int i_d_0 = 0; i_d_0 < 2; i_d_0++)
         {
-          localTensor[(i_ele + n_ele * i_r_0)] += CG1[(i_r_0 + 3 * i_g)] * c_q0[(i_g + 6 * i_d_0)] * detwei[(i_ele + n_ele * i_g)];
+          localTensor[(i_ele + n_ele * i_r_0)] += CG1_v[i_d_0][i_r_0][i_g] * c_q0[(i_g + 6 * i_d_0)] * detwei[(i_ele + n_ele * i_g)];
         };
       };
     };

--- a/tests/expected/op2/identity-vector.cpp
+++ b/tests/expected/op2/identity-vector.cpp
@@ -11,7 +11,7 @@ void A(double localTensor[3][3], double dt, double detwei[6], double CG1[3][6])
       {
         for(int i_d_0 = 0; i_d_0 < 2; i_d_0++)
         {
-          localTensor[i_r_0][i_r_1] += CG1[i_r_0][i_g] * CG1[i_r_1][i_g] * detwei[i_g];
+          localTensor[i_r_0][i_r_1] += CG1_v[i_r_0][i_g] * CG1_v[i_r_1][i_g] * detwei[i_g];
         };
       };
     };
@@ -39,7 +39,7 @@ void RHS(double localTensor[3], double dt, double detwei[6], double c0[2][3], do
     {
       for(int i_d_0 = 0; i_d_0 < 2; i_d_0++)
       {
-        localTensor[i_r_0] += CG1[i_r_0][i_g] * c_q0[i_g][i_d_0] * detwei[i_g];
+        localTensor[i_r_0] += CG1_v[i_r_0][i_g] * c_q0[i_g][i_d_0] * detwei[i_g];
       };
     };
   };


### PR DESCRIPTION
Changes to support code generation of the local assembly when we're solving for vector fields. The changes consist of:
1. When there is a vector basis function, this is the tensor product of a scalar basis. This needs to be put in an array at the start of the kernel. The new function `_buildBasisTensors` generates the code to declare this array and populate it with the correct terms from the scalar basis.
2. Since the vector basis is a multidimensional array, support for multidimensional array subscripts has been added to the CUDA backend. When code referencing a vector basis is generated, it uses `buildMultiArraySubscript` instead of `buildArraySubscript` so that it matches with the type of the array storing the vector basis. 
3. Since vector bases have an additional index that is present in the UFL AST, we need to memorise what the indices are when we encounter an `Indexed` object. This is so that the indices can be referenced by the code that generates the array subscript for the vector basis. This memorisation is taken care of in the `indexed` and `multi_index` methods of `ExpressionBuilder`.
4. Computation of the number of basis functions for a vector or tensor basis is added, in order to get the correct upper bounds of loops over a vector basis. 

Caveats:
1. Some of the changes cause modification to the output of op2 `identity-vector` test case. How do we feel about this? I imagine the rest of the functionality will need porting into op2 as well when we start using it as a backend instead of the CUDA one.
2. The code only works for forms with arguments, not for argument derivatives - this is because the generated code was very messy for initialising the tensor product of the derivatives of the basis functions, and additionally this code had to go inside the element loop, which would have made its cost non-trivial. Once we can generate the transformation in the form kernel, this will be far easier to implement since we will need the tensor product of derivatives of the basis functions on the reference element, which will only need doing once outside the element loop and be simpler code.
