### PR TITLE
Fix indexing

### DIFF
--- a/mcfc/cudaexpression.py
+++ b/mcfc/cudaexpression.py
@@ -20,6 +20,8 @@
 from expression import *
 from cudaparameters import numElements
 
+import ufl.differentiation
+
 # Variables
 
 threadCount = Variable("THREAD_COUNT")
@@ -145,15 +147,19 @@ class CudaExpressionBuilder(ExpressionBuilder):
     def subscript_CoeffQuadrature(self, coeff):
         # Build the subscript based on the rank
         indices = [self._form.buildGaussIndex()]
-        depth = coeff.rank()
+        rank = coeff.rank()
 
-        if coeff.rank() != 0:
+        if isinstance(coeff, ufl.differentiation.SpatialDerivative):
+            rank = rank + 1 
+
+        if rank != 0:
             print "Rank: %d" % coeff.rank()
             dimIndices = self._indexStack.peek()
-            if len(dimIndices) != coeff.rank():
-                raise RuntimeError("Number of indices does not match rank of coefficient. %d vs %d." % (len(dimIndices), coeff.rank()))
+            if len(dimIndices) != rank:
+                raise RuntimeError("Number of indices does not match rank of coefficient. %d vs %d." % (len(dimIndices), rank))
             for i in dimIndices:
-                indices.append(self._form.buildDimIndex(i))
+                print "Count: ", i.count()
+                indices.append(self._form.buildDimIndex(i.count()))
         
         return indices
 

--- a/mcfc/cudaexpression.py
+++ b/mcfc/cudaexpression.py
@@ -153,12 +153,10 @@ class CudaExpressionBuilder(ExpressionBuilder):
             rank = rank + 1 
 
         if rank != 0:
-            print "Rank: %d" % coeff.rank()
             dimIndices = self._indexStack.peek()
             if len(dimIndices) != rank:
                 raise RuntimeError("Number of indices does not match rank of coefficient. %d vs %d." % (len(dimIndices), rank))
             for i in dimIndices:
-                print "Count: ", i.count()
                 indices.append(self._form.buildDimIndex(i.count()))
         
         return indices

--- a/mcfc/cudaexpression.py
+++ b/mcfc/cudaexpression.py
@@ -106,23 +106,22 @@ class CudaExpressionBuilder(ExpressionBuilder):
         indices = indices + [self._form.buildBasisIndex(count), self._form.buildGaussIndex()]
         return indices
 
-    def subscript_SpatialDerivative(self,tree,depth):
+    def subscript_SpatialDerivative(self,tree,dimIndices):
         # Build the subscript based on the argument count and the
-        # nesting depth of IndexSums of the expression.
+        # indices
         operand, _ = tree.operands()
         count = operand.count()
 
         if isinstance(operand, ufl.argument.Argument):
-            indices = [ ElementIndex(),
-                        self._form.buildDimIndex(depth),
-                        self._form.buildGaussIndex(),
-                        self._form.buildBasisIndex(count) ]
+            indices = [ ElementIndex()]
+            for i in dimIndices:
+                indices.append(self._form.buildDimIndex(i.count()))
+            indices = indices + [ self._form.buildGaussIndex(),
+                                  self._form.buildBasisIndex(count) ]
         elif isinstance(operand, ufl.coefficient.Coefficient):
             indices = [ self._form.buildGaussIndex() ]
-            depth = operand.rank() + 1
-
-            for r in range(depth):
-                indices.append(self._form.buildDimIndex(r))
+            for i in dimIndices:
+                indices.append(self._form.buildDimIndex(i.count()))
 
         return indices
 
@@ -147,12 +146,14 @@ class CudaExpressionBuilder(ExpressionBuilder):
         # Build the subscript based on the rank
         indices = [self._form.buildGaussIndex()]
         depth = coeff.rank()
-        if isinstance(coeff, ufl.differentiation.SpatialDerivative):
-            # We need to add one, since the differentiation added a 
-            # dim index
-            depth = depth + 1
-        for r in range(depth):
-            indices.append(self._form.buildDimIndex(r))
+
+        if coeff.rank() != 0:
+            print "Rank: %d" % coeff.rank()
+            dimIndices = self._indexStack.peek()
+            if len(dimIndices) != coeff.rank():
+                raise RuntimeError("Number of indices does not match rank of coefficient. %d vs %d." % (len(dimIndices), coeff.rank()))
+            for i in dimIndices:
+                indices.append(self._form.buildDimIndex(i))
         
         return indices
 

--- a/mcfc/cudaform.py
+++ b/mcfc/cudaform.py
@@ -222,12 +222,14 @@ class CudaFormBackend(FormBackend):
         # Determine how many dimension loops we need by inspection.
         # We count the nesting depth of IndexSums to determine
         # how many dimension loops we need.
-        numDimLoops = self._indexSumCounter.count(integrand)
+        dimLoops = indexSumIndices(integrand)
 
         # Add loops for each dimension as necessary. 
-        for d in range(numDimLoops):
-            indVarName = self.buildDimIndex(d).name()
-            dimLoop = buildSimpleForLoop(indVarName, self.numDimensions)
+        for d in dimLoops:
+            print d['count']
+            print d['extent']
+            indVarName = self.buildDimIndex(d['count']).name()
+            dimLoop = buildSimpleForLoop(indVarName, d['extent'])
             loop.append(dimLoop)
             loop = dimLoop
 

--- a/mcfc/cudaform.py
+++ b/mcfc/cudaform.py
@@ -31,7 +31,6 @@ class CudaFormBackend(FormBackend):
         FormBackend.__init__(self)
         self._expressionBuilder = CudaExpressionBuilder(self)
         self._quadratureExpressionBuilder = CudaQuadratureExpressionBuilder(self)
-        self._indexSumCounter = IndexSumCounter()
 
     def compile(self, name, form):
         "Compile a form with a given name."
@@ -226,8 +225,6 @@ class CudaFormBackend(FormBackend):
 
         # Add loops for each dimension as necessary. 
         for d in dimLoops:
-            print d['count']
-            print d['extent']
             indVarName = self.buildDimIndex(d['count']).name()
             dimLoop = buildSimpleForLoop(indVarName, d['extent'])
             loop.append(dimLoop)

--- a/mcfc/expression.py
+++ b/mcfc/expression.py
@@ -34,7 +34,6 @@ class ExpressionBuilder(Transformer):
         "Build the rhs for evaluating an expression tree."
         self._exprStack = []
         self._indexStack = Stack()
-        self._indexSumIndexStack = Stack()
         self.visit(tree)
 
         expr = self._exprStack.pop()
@@ -77,9 +76,7 @@ class ExpressionBuilder(Transformer):
     def index_sum(self, tree):
         summand, mi = tree.operands()
 
-        self._indexSumIndexStack.push(self.visit(mi))
         self.visit(summand)
-        self._indexSumIndexStack.pop()
 
     def constant_value(self, tree):
         if isinstance(tree, SymbolicValue):
@@ -104,7 +101,7 @@ class ExpressionBuilder(Transformer):
         name = buildSpatialDerivativeName(tree)
         base = Variable(name)
 
-        dimIndices = self._indexSumIndexStack.peek()
+        dimIndices = self._indexStack.peek()
         indices = self.subscript(tree, dimIndices)
         spatialDerivExpr = self.buildSubscript(base, indices)
         self._exprStack.append(spatialDerivExpr)

--- a/mcfc/expression.py
+++ b/mcfc/expression.py
@@ -126,7 +126,8 @@ class ExpressionBuilder(Transformer):
         self._exprStack.append(argExpr)
 
     def coefficient(self, tree):
-        coeffExpr = self.buildCoeffQuadratureAccessor(tree, True)
+        print "Real indices: ", self._indexStack
+        coeffExpr = self.buildCoeffQuadratureAccessor(tree)
         self._exprStack.append(coeffExpr)
 
     def buildCoeffQuadratureAccessor(self, coeff, fake_indices=False):
@@ -146,12 +147,12 @@ class ExpressionBuilder(Transformer):
         if fake_indices:
             fake = []
             for i in range(rank):
-                fake.append(i)
-            print fake
+                fake.append(Index(i))
             self._indexStack.push(tuple(fake))
-            print self._indexStack
+            print "fake indices: ", self._indexStack
 
         indices = self.subscript_CoeffQuadrature(coeff)
+        print indices
 
         # Remove the fake indices
         if fake_indices:

--- a/mcfc/expression.py
+++ b/mcfc/expression.py
@@ -126,10 +126,10 @@ class ExpressionBuilder(Transformer):
         self._exprStack.append(argExpr)
 
     def coefficient(self, tree):
-        coeffExpr = self.buildCoeffQuadratureAccessor(tree)
+        coeffExpr = self.buildCoeffQuadratureAccessor(tree, True)
         self._exprStack.append(coeffExpr)
 
-    def buildCoeffQuadratureAccessor(self, coeff):
+    def buildCoeffQuadratureAccessor(self, coeff, fake_indices=False):
         rank = coeff.rank()
         if isinstance(coeff, ufl.coefficient.Coefficient):
             name = buildCoefficientQuadName(coeff)
@@ -140,19 +140,22 @@ class ExpressionBuilder(Transformer):
             name = buildSpatialDerivativeName(coeff)
         base = Variable(name)
         
+        print "Expected rank: %d" % rank
         # If there are no indices present (e.g. in the quadrature evaluation loop) then
         # we need to fake indices for the coefficient based on its rank:
-        #if len(self._indexStack) == 0:
-        fake_indices = []
-        for i in range(rank):
-            fake_indices.append(i)
-        self._indexStack.push(tuple(fake_indices))
+        if fake_indices:
+            fake = []
+            for i in range(rank):
+                fake.append(i)
+            print fake
+            self._indexStack.push(tuple(fake))
+            print self._indexStack
 
         indices = self.subscript_CoeffQuadrature(coeff)
 
         # Remove the fake indices
-        #if len(self._indexStack) == 0:
-        self._indexStack.pop()
+        if fake_indices:
+            self._indexStack.pop()
 
         coeffExpr = self.buildSubscript(base, indices)
         return coeffExpr

--- a/mcfc/expression.py
+++ b/mcfc/expression.py
@@ -126,7 +126,6 @@ class ExpressionBuilder(Transformer):
         self._exprStack.append(argExpr)
 
     def coefficient(self, tree):
-        print "Real indices: ", self._indexStack
         coeffExpr = self.buildCoeffQuadratureAccessor(tree)
         self._exprStack.append(coeffExpr)
 
@@ -141,7 +140,6 @@ class ExpressionBuilder(Transformer):
             name = buildSpatialDerivativeName(coeff)
         base = Variable(name)
         
-        print "Expected rank: %d" % rank
         # If there are no indices present (e.g. in the quadrature evaluation loop) then
         # we need to fake indices for the coefficient based on its rank:
         if fake_indices:
@@ -149,10 +147,8 @@ class ExpressionBuilder(Transformer):
             for i in range(rank):
                 fake.append(Index(i))
             self._indexStack.push(tuple(fake))
-            print "fake indices: ", self._indexStack
 
         indices = self.subscript_CoeffQuadrature(coeff)
-        print indices
 
         # Remove the fake indices
         if fake_indices:

--- a/mcfc/expression.py
+++ b/mcfc/expression.py
@@ -34,9 +34,7 @@ class ExpressionBuilder(Transformer):
         "Build the rhs for evaluating an expression tree."
         self._exprStack = []
         self._indexStack = Stack()
-        # When we pass through the first IndexSum, this will get incremented
-        # to 0, which is the count of the first dim index
-        self._indexSumDepth = -1 
+        self._indexSumIndexStack = Stack()
         self.visit(tree)
 
         expr = self._exprStack.pop()
@@ -77,10 +75,11 @@ class ExpressionBuilder(Transformer):
     # We need to keep track of how many IndexSums we passed through
     # so that we know which dim index we're dealing with.
     def index_sum(self, tree):
-        summand, indices = tree.operands()
-        self._indexSumDepth = self._indexSumDepth + 1
+        summand, mi = tree.operands()
+
+        self._indexSumIndexStack.push(self.visit(mi))
         self.visit(summand)
-        self._indexSumDepth = self._indexSumDepth - 1
+        self._indexSumIndexStack.pop()
 
     def constant_value(self, tree):
         if isinstance(tree, SymbolicValue):
@@ -105,8 +104,8 @@ class ExpressionBuilder(Transformer):
         name = buildSpatialDerivativeName(tree)
         base = Variable(name)
 
-        depth = self._indexSumDepth
-        indices = self.subscript(tree, depth)
+        dimIndices = self._indexSumIndexStack.peek()
+        indices = self.subscript(tree, dimIndices)
         spatialDerivExpr = self.buildSubscript(base, indices)
         self._exprStack.append(spatialDerivExpr)
  
@@ -131,13 +130,29 @@ class ExpressionBuilder(Transformer):
         self._exprStack.append(coeffExpr)
 
     def buildCoeffQuadratureAccessor(self, coeff):
+        rank = coeff.rank()
         if isinstance(coeff, ufl.coefficient.Coefficient):
             name = buildCoefficientQuadName(coeff)
         else:
+            # The spatial derivative adds an extra dim index so we need to
+            # bump up the rank
+            rank = rank + 1
             name = buildSpatialDerivativeName(coeff)
         base = Variable(name)
         
+        # If there are no indices present (e.g. in the quadrature evaluation loop) then
+        # we need to fake indices for the coefficient based on its rank:
+        #if len(self._indexStack) == 0:
+        fake_indices = []
+        for i in range(rank):
+            fake_indices.append(i)
+        self._indexStack.push(tuple(fake_indices))
+
         indices = self.subscript_CoeffQuadrature(coeff)
+
+        # Remove the fake indices
+        #if len(self._indexStack) == 0:
+        self._indexStack.pop()
 
         coeffExpr = self.buildSubscript(base, indices)
         return coeffExpr

--- a/mcfc/form.py
+++ b/mcfc/form.py
@@ -189,7 +189,6 @@ class IndexSumIndexFinder(Transformer):
         summand, mi = tree.operands()
         indices = mi.index_dimensions()
 
-        print indices
         for c, d in indices.items():
             self._indices.append({"count": c.count(), "extent": d})
 

--- a/mcfc/form.py
+++ b/mcfc/form.py
@@ -69,7 +69,7 @@ class FormBackend:
         "Build the expression to evaluate a particular coefficient."
         rhs = self._quadratureExpressionBuilder.build(coeff)
 
-        lhs = self._expressionBuilder.buildCoeffQuadratureAccessor(coeff)
+        lhs = self._expressionBuilder.buildCoeffQuadratureAccessor(coeff, True)
         expr = PlusAssignmentOp(lhs, rhs)
         
         return expr
@@ -81,7 +81,7 @@ class FormBackend:
         return initialiser
 
     def buildCoeffQuadratureInitialiser(self, coeff):
-        accessor = self._expressionBuilder.buildCoeffQuadratureAccessor(coeff)
+        accessor = self._expressionBuilder.buildCoeffQuadratureAccessor(coeff, True)
         initialiser = AssignmentOp(accessor, Literal(0.0))
         return initialiser
 

--- a/mcfc/form.py
+++ b/mcfc/form.py
@@ -176,6 +176,33 @@ class CoefficientUseFinder(Transformer):
     def coefficient(self, tree):
         self._coefficients.append(tree)
 
+class IndexSumIndexFinder(Transformer):
+    "Find the count and extent of indices reduced by an IndexSum in a form."
+
+    def find(self, tree):
+        self._indices = []
+        self.visit(tree)
+        return self._indices
+
+    def index_sum(self, tree):
+
+        summand, mi = tree.operands()
+        indices = mi.index_dimensions()
+
+        print indices
+        for c, d in indices.items():
+            self._indices.append({"count": c.count(), "extent": d})
+
+        self.visit(summand)
+
+    # We don't care about any other node.
+    def expr(self, tree, *ops):
+        pass
+
+def indexSumIndices(tree):
+    ISIF = IndexSumIndexFinder()
+    return ISIF.find(tree)
+
 class IndexSumCounter(Transformer):
     "Count how many IndexSums are nested inside a tree."
 

--- a/mcfc/op2expression.py
+++ b/mcfc/op2expression.py
@@ -53,24 +53,22 @@ class Op2ExpressionBuilder(ExpressionBuilder):
         indices = [self._form.buildBasisIndex(count), self._form.buildGaussIndex()]
         return indices
 
-    def subscript_SpatialDerivative(self,tree,depth):
+    def subscript_SpatialDerivative(self,tree,dimIndices):
         # Build the subscript based on the argument count and the
         # nesting depth of IndexSums of the expression.
         operand, _ = tree.operands()
         count = operand.count()
 
         if isinstance(operand, ufl.argument.Argument):
-            indices = [ self._form.buildDimIndex(depth),
-                        self._form.buildGaussIndex(),
-                        self._form.buildBasisIndex(count) ]
+            indices = [] 
+            for i in dimIndices:
+                indices.append(self._form.buildDimIndex(i.count()))
+            indices = indices + [ self._form.buildGaussIndex(),
+                                  self._form.buildBasisIndex(count) ]
         elif isinstance(operand, ufl.coefficient.Coefficient):
             indices = [ self._form.buildGaussIndex() ]
-            # We need to add one, since the differentiation added a 
-            # dim index
-            depth = operand.rank() + 1
-
-            for r in range(depth):
-                indices.append(self._form.buildDimIndex(r))
+            for i in dimIndices:
+                indices.append(self._form.buildDimIndex(i.count()))
 
         return indices
 
@@ -93,12 +91,12 @@ class Op2ExpressionBuilder(ExpressionBuilder):
         # Build the subscript based on the rank
         indices = [self._form.buildGaussIndex()]
         depth = coeff.rank()
-        if isinstance(coeff, ufl.differentiation.SpatialDerivative):
-            # We need to add one, since the differentiation added a 
-            # dim index
-            depth = depth + 1
-        for r in range(depth):
-            indices.append(self._form.buildDimIndex(r))
+        if coeff.rank() != 0:
+            dimIndices = self._indexStack.peek()
+            if len(dimIndices) != coeff.rank():
+                raise RuntimeError("Number of indices does not match rank of coefficient. %d vs %d." % (len(dimIndices), coeff.rank()))
+            for i in dimIndices:
+                indices.append(self._form.buildDimIndex(i))
         
         return indices
 

--- a/mcfc/op2expression.py
+++ b/mcfc/op2expression.py
@@ -90,13 +90,16 @@ class Op2ExpressionBuilder(ExpressionBuilder):
     def subscript_CoeffQuadrature(self, coeff):
         # Build the subscript based on the rank
         indices = [self._form.buildGaussIndex()]
-        depth = coeff.rank()
-        if coeff.rank() != 0:
+        rank = coeff.rank()
+
+        if isinstance(coeff, ufl.differentiation.SpatialDerivative):
+            rank = rank + 1
+        if rank != 0:
             dimIndices = self._indexStack.peek()
-            if len(dimIndices) != coeff.rank():
-                raise RuntimeError("Number of indices does not match rank of coefficient. %d vs %d." % (len(dimIndices), coeff.rank()))
+            if len(dimIndices) != rank:
+                raise RuntimeError("Number of indices does not match rank of coefficient. %d vs %d." % (len(dimIndices), rank))
             for i in dimIndices:
-                indices.append(self._form.buildDimIndex(i))
+                indices.append(self._form.buildDimIndex(i.count()))
         
         return indices
 

--- a/mcfc/op2form.py
+++ b/mcfc/op2form.py
@@ -29,7 +29,6 @@ class Op2FormBackend(FormBackend):
         FormBackend.__init__(self)
         self._expressionBuilder = Op2ExpressionBuilder(self)
         self._quadratureExpressionBuilder = Op2QuadratureExpressionBuilder(self)
-        self._indexSumCounter = IndexSumCounter()
 
     def compile(self, name, form):
 
@@ -167,12 +166,12 @@ class Op2FormBackend(FormBackend):
         # Determine how many dimension loops we need by inspection.
         # We count the nesting depth of IndexSums to determine
         # how many dimension loops we need.
-        numDimLoops = self._indexSumCounter.count(integrand)
+        dimLoops = indexSumIndices(integrand)
 
         # Add loops for each dimension as necessary. 
-        for d in range(numDimLoops):
-            indVarName = self.buildDimIndex(d).name()
-            dimLoop = buildSimpleForLoop(indVarName, self.numDimensions)
+        for d in dimLoops:
+            indVarName = self.buildDimIndex(d['count']).name()
+            dimLoop = buildSimpleForLoop(indVarName, d['extent'])
             loop.append(dimLoop)
             loop = dimLoop
 

--- a/tests/autotest.py
+++ b/tests/autotest.py
@@ -52,7 +52,7 @@ def main():
     check_optionfile = 'no-optionfile' not in keys
     check_visualiser = 'no-visualiser' not in keys
 
-    ufl_sources = ['noop', 'diffusion-3', 'identity', \
+    ufl_sources = ['noop', 'diffusion-1', 'diffusion-2', 'diffusion-3', 'identity', \
             'laplacian', 'helmholtz', 'euler-advection', 'identity-vector', \
             'simple-advection-diffusion' ]
     optionfile_sources = ['test', 'cdisk_adv_diff']

--- a/tests/autotest.py
+++ b/tests/autotest.py
@@ -52,7 +52,7 @@ def main():
     check_optionfile = 'no-optionfile' not in keys
     check_visualiser = 'no-visualiser' not in keys
 
-    ufl_sources = ['noop', 'diffusion-1', 'diffusion-2', 'diffusion-3', 'identity', \
+    ufl_sources = ['noop', 'diffusion-3', 'identity', \
             'laplacian', 'helmholtz', 'euler-advection', 'identity-vector', \
             'simple-advection-diffusion' ]
     optionfile_sources = ['test', 'cdisk_adv_diff']

--- a/tests/expected/cuda/diffusion-1.cu
+++ b/tests/expected/cuda/diffusion-1.cu
@@ -46,7 +46,7 @@ __global__ void A(double* localTensor, int n_ele, double dt, double* detwei, dou
           {
             for(int i_d_0 = 0; i_d_0 < 2; i_d_0++)
             {
-              localTensor[((i_ele + n_ele * i_r_0) + 3 * n_ele * i_r_1)] += -1 * 0.5 * c_q0[((i_g + 6 * i_d_0) + 2 * 6 * i_d_1)] * -1 * d_CG1[(((i_ele + n_ele * i_d_1) + 2 * n_ele * i_g) + 6 * 2 * n_ele * i_r_0)] * d_CG1[(((i_ele + n_ele * i_d_0) + 2 * n_ele * i_g) + 6 * 2 * n_ele * i_r_1)] * detwei[(i_ele + n_ele * i_g)];
+              localTensor[((i_ele + n_ele * i_r_0) + 3 * n_ele * i_r_1)] += -1 * 0.5 * c_q0[((i_g + 6 * i_d_0) + 2 * 6 * i_d_1)] * -1 * d_CG1[(((i_ele + n_ele * i_d_0) + 2 * n_ele * i_g) + 6 * 2 * n_ele * i_r_0)] * d_CG1[(((i_ele + n_ele * i_d_1) + 2 * n_ele * i_g) + 6 * 2 * n_ele * i_r_1)] * detwei[(i_ele + n_ele * i_g)];
             };
           };
         };
@@ -85,7 +85,7 @@ __global__ void d(double* localTensor, int n_ele, double dt, double* detwei, dou
           {
             for(int i_d_0 = 0; i_d_0 < 2; i_d_0++)
             {
-              localTensor[((i_ele + n_ele * i_r_0) + 3 * n_ele * i_r_1)] += c_q0[((i_g + 6 * i_d_0) + 2 * 6 * i_d_1)] * -1 * d_CG1[(((i_ele + n_ele * i_d_1) + 2 * n_ele * i_g) + 6 * 2 * n_ele * i_r_0)] * d_CG1[(((i_ele + n_ele * i_d_0) + 2 * n_ele * i_g) + 6 * 2 * n_ele * i_r_1)] * detwei[(i_ele + n_ele * i_g)];
+              localTensor[((i_ele + n_ele * i_r_0) + 3 * n_ele * i_r_1)] += c_q0[((i_g + 6 * i_d_0) + 2 * 6 * i_d_1)] * -1 * d_CG1[(((i_ele + n_ele * i_d_0) + 2 * n_ele * i_g) + 6 * 2 * n_ele * i_r_0)] * d_CG1[(((i_ele + n_ele * i_d_1) + 2 * n_ele * i_g) + 6 * 2 * n_ele * i_r_1)] * detwei[(i_ele + n_ele * i_g)];
             };
           };
         };
@@ -156,7 +156,7 @@ __global__ void rhs(double* localTensor, int n_ele, double dt, double* detwei, d
         {
           for(int i_d_0 = 0; i_d_0 < 2; i_d_0++)
           {
-            localTensor[(i_ele + n_ele * i_r_0)] += 0.5 * c_q1[((i_g + 6 * i_d_0) + 2 * 6 * i_d_1)] * -1 * d_CG1[(((i_ele + n_ele * i_d_1) + 2 * n_ele * i_g) + 6 * 2 * n_ele * i_r_0)] * d_c_q0[(i_g + 6 * i_d_0)] * detwei[(i_ele + n_ele * i_g)];
+            localTensor[(i_ele + n_ele * i_r_0)] += 0.5 * c_q1[((i_g + 6 * i_d_0) + 2 * 6 * i_d_1)] * -1 * d_CG1[(((i_ele + n_ele * i_d_0) + 2 * n_ele * i_g) + 6 * 2 * n_ele * i_r_0)] * d_c_q0[(i_g + 6 * i_d_0)] * detwei[(i_ele + n_ele * i_g)];
           };
         };
       };

--- a/tests/expected/cuda/diffusion-1.cu
+++ b/tests/expected/cuda/diffusion-1.cu
@@ -42,9 +42,9 @@ __global__ void A(double* localTensor, int n_ele, double dt, double* detwei, dou
         for(int i_g = 0; i_g < 6; i_g++)
         {
           localTensor[((i_ele + n_ele * i_r_0) + 3 * n_ele * i_r_1)] += CG1[(i_r_0 + 3 * i_g)] * CG1[(i_r_1 + 3 * i_g)] * detwei[(i_ele + n_ele * i_g)];
-          for(int i_d_0 = 0; i_d_0 < 2; i_d_0++)
+          for(int i_d_1 = 0; i_d_1 < 2; i_d_1++)
           {
-            for(int i_d_1 = 0; i_d_1 < 2; i_d_1++)
+            for(int i_d_0 = 0; i_d_0 < 2; i_d_0++)
             {
               localTensor[((i_ele + n_ele * i_r_0) + 3 * n_ele * i_r_1)] += -1 * 0.5 * c_q0[((i_g + 6 * i_d_0) + 2 * 6 * i_d_1)] * -1 * d_CG1[(((i_ele + n_ele * i_d_1) + 2 * n_ele * i_g) + 6 * 2 * n_ele * i_r_0)] * d_CG1[(((i_ele + n_ele * i_d_0) + 2 * n_ele * i_g) + 6 * 2 * n_ele * i_r_1)] * detwei[(i_ele + n_ele * i_g)];
             };
@@ -81,9 +81,9 @@ __global__ void d(double* localTensor, int n_ele, double dt, double* detwei, dou
         localTensor[((i_ele + n_ele * i_r_0) + 3 * n_ele * i_r_1)] = 0.0;
         for(int i_g = 0; i_g < 6; i_g++)
         {
-          for(int i_d_0 = 0; i_d_0 < 2; i_d_0++)
+          for(int i_d_1 = 0; i_d_1 < 2; i_d_1++)
           {
-            for(int i_d_1 = 0; i_d_1 < 2; i_d_1++)
+            for(int i_d_0 = 0; i_d_0 < 2; i_d_0++)
             {
               localTensor[((i_ele + n_ele * i_r_0) + 3 * n_ele * i_r_1)] += c_q0[((i_g + 6 * i_d_0) + 2 * 6 * i_d_1)] * -1 * d_CG1[(((i_ele + n_ele * i_d_1) + 2 * n_ele * i_g) + 6 * 2 * n_ele * i_r_0)] * d_CG1[(((i_ele + n_ele * i_d_0) + 2 * n_ele * i_g) + 6 * 2 * n_ele * i_r_1)] * detwei[(i_ele + n_ele * i_g)];
             };
@@ -152,9 +152,9 @@ __global__ void rhs(double* localTensor, int n_ele, double dt, double* detwei, d
       for(int i_g = 0; i_g < 6; i_g++)
       {
         localTensor[(i_ele + n_ele * i_r_0)] += CG1[(i_r_0 + 3 * i_g)] * c_q0[i_g] * detwei[(i_ele + n_ele * i_g)];
-        for(int i_d_0 = 0; i_d_0 < 2; i_d_0++)
+        for(int i_d_1 = 0; i_d_1 < 2; i_d_1++)
         {
-          for(int i_d_1 = 0; i_d_1 < 2; i_d_1++)
+          for(int i_d_0 = 0; i_d_0 < 2; i_d_0++)
           {
             localTensor[(i_ele + n_ele * i_r_0)] += 0.5 * c_q1[((i_g + 6 * i_d_0) + 2 * 6 * i_d_1)] * -1 * d_CG1[(((i_ele + n_ele * i_d_1) + 2 * n_ele * i_g) + 6 * 2 * n_ele * i_r_0)] * d_c_q0[(i_g + 6 * i_d_0)] * detwei[(i_ele + n_ele * i_g)];
           };

--- a/tests/expected/cuda/diffusion-1.cu
+++ b/tests/expected/cuda/diffusion-1.cu
@@ -156,7 +156,7 @@ __global__ void rhs(double* localTensor, int n_ele, double dt, double* detwei, d
         {
           for(int i_d_0 = 0; i_d_0 < 2; i_d_0++)
           {
-            localTensor[(i_ele + n_ele * i_r_0)] += 0.5 * c_q1[((i_g + 6 * i_d_0) + 2 * 6 * i_d_1)] * -1 * d_CG1[(((i_ele + n_ele * i_d_0) + 2 * n_ele * i_g) + 6 * 2 * n_ele * i_r_0)] * d_c_q0[(i_g + 6 * i_d_0)] * detwei[(i_ele + n_ele * i_g)];
+            localTensor[(i_ele + n_ele * i_r_0)] += 0.5 * c_q1[((i_g + 6 * i_d_0) + 2 * 6 * i_d_1)] * -1 * d_CG1[(((i_ele + n_ele * i_d_0) + 2 * n_ele * i_g) + 6 * 2 * n_ele * i_r_0)] * d_c_q0[(i_g + 6 * i_d_1)] * detwei[(i_ele + n_ele * i_g)];
           };
         };
       };

--- a/tests/expected/cuda/diffusion-2.cu
+++ b/tests/expected/cuda/diffusion-2.cu
@@ -46,7 +46,7 @@ __global__ void A(double* localTensor, int n_ele, double dt, double* detwei, dou
           {
             for(int i_d_0 = 0; i_d_0 < 2; i_d_0++)
             {
-              localTensor[((i_ele + n_ele * i_r_0) + 3 * n_ele * i_r_1)] += -1 * 0.5 * -1 * c_q0[((i_g + 6 * i_d_0) + 2 * 6 * i_d_1)] * d_CG1[(((i_ele + n_ele * i_d_1) + 2 * n_ele * i_g) + 6 * 2 * n_ele * i_r_0)] * d_CG1[(((i_ele + n_ele * i_d_0) + 2 * n_ele * i_g) + 6 * 2 * n_ele * i_r_1)] * detwei[(i_ele + n_ele * i_g)];
+              localTensor[((i_ele + n_ele * i_r_0) + 3 * n_ele * i_r_1)] += -1 * 0.5 * -1 * c_q0[((i_g + 6 * i_d_0) + 2 * 6 * i_d_1)] * d_CG1[(((i_ele + n_ele * i_d_0) + 2 * n_ele * i_g) + 6 * 2 * n_ele * i_r_0)] * d_CG1[(((i_ele + n_ele * i_d_3) + 2 * n_ele * i_g) + 6 * 2 * n_ele * i_r_1)] * detwei[(i_ele + n_ele * i_g)];
             };
           };
         };
@@ -85,7 +85,7 @@ __global__ void d(double* localTensor, int n_ele, double dt, double* detwei, dou
           {
             for(int i_d_0 = 0; i_d_0 < 2; i_d_0++)
             {
-              localTensor[((i_ele + n_ele * i_r_0) + 3 * n_ele * i_r_1)] += -1 * c_q0[((i_g + 6 * i_d_0) + 2 * 6 * i_d_1)] * d_CG1[(((i_ele + n_ele * i_d_1) + 2 * n_ele * i_g) + 6 * 2 * n_ele * i_r_0)] * d_CG1[(((i_ele + n_ele * i_d_0) + 2 * n_ele * i_g) + 6 * 2 * n_ele * i_r_1)] * detwei[(i_ele + n_ele * i_g)];
+              localTensor[((i_ele + n_ele * i_r_0) + 3 * n_ele * i_r_1)] += -1 * c_q0[((i_g + 6 * i_d_0) + 2 * 6 * i_d_1)] * d_CG1[(((i_ele + n_ele * i_d_0) + 2 * n_ele * i_g) + 6 * 2 * n_ele * i_r_0)] * d_CG1[(((i_ele + n_ele * i_d_3) + 2 * n_ele * i_g) + 6 * 2 * n_ele * i_r_1)] * detwei[(i_ele + n_ele * i_g)];
             };
           };
         };
@@ -156,7 +156,7 @@ __global__ void rhs(double* localTensor, int n_ele, double dt, double* detwei, d
         {
           for(int i_d_0 = 0; i_d_0 < 2; i_d_0++)
           {
-            localTensor[(i_ele + n_ele * i_r_0)] += 0.5 * -1 * c_q1[((i_g + 6 * i_d_0) + 2 * 6 * i_d_1)] * d_CG1[(((i_ele + n_ele * i_d_1) + 2 * n_ele * i_g) + 6 * 2 * n_ele * i_r_0)] * d_c_q0[(i_g + 6 * i_d_0)] * detwei[(i_ele + n_ele * i_g)];
+            localTensor[(i_ele + n_ele * i_r_0)] += 0.5 * -1 * c_q1[((i_g + 6 * i_d_0) + 2 * 6 * i_d_1)] * d_CG1[(((i_ele + n_ele * i_d_0) + 2 * n_ele * i_g) + 6 * 2 * n_ele * i_r_0)] * d_c_q0[(i_g + 6 * i_d_0)] * detwei[(i_ele + n_ele * i_g)];
           };
         };
       };

--- a/tests/expected/cuda/diffusion-2.cu
+++ b/tests/expected/cuda/diffusion-2.cu
@@ -42,9 +42,9 @@ __global__ void A(double* localTensor, int n_ele, double dt, double* detwei, dou
         for(int i_g = 0; i_g < 6; i_g++)
         {
           localTensor[((i_ele + n_ele * i_r_0) + 3 * n_ele * i_r_1)] += CG1[(i_r_0 + 3 * i_g)] * CG1[(i_r_1 + 3 * i_g)] * detwei[(i_ele + n_ele * i_g)];
-          for(int i_d_0 = 0; i_d_0 < 2; i_d_0++)
+          for(int i_d_3 = 0; i_d_3 < 2; i_d_3++)
           {
-            for(int i_d_1 = 0; i_d_1 < 2; i_d_1++)
+            for(int i_d_0 = 0; i_d_0 < 2; i_d_0++)
             {
               localTensor[((i_ele + n_ele * i_r_0) + 3 * n_ele * i_r_1)] += -1 * 0.5 * -1 * c_q0[((i_g + 6 * i_d_0) + 2 * 6 * i_d_1)] * d_CG1[(((i_ele + n_ele * i_d_1) + 2 * n_ele * i_g) + 6 * 2 * n_ele * i_r_0)] * d_CG1[(((i_ele + n_ele * i_d_0) + 2 * n_ele * i_g) + 6 * 2 * n_ele * i_r_1)] * detwei[(i_ele + n_ele * i_g)];
             };
@@ -81,9 +81,9 @@ __global__ void d(double* localTensor, int n_ele, double dt, double* detwei, dou
         localTensor[((i_ele + n_ele * i_r_0) + 3 * n_ele * i_r_1)] = 0.0;
         for(int i_g = 0; i_g < 6; i_g++)
         {
-          for(int i_d_0 = 0; i_d_0 < 2; i_d_0++)
+          for(int i_d_3 = 0; i_d_3 < 2; i_d_3++)
           {
-            for(int i_d_1 = 0; i_d_1 < 2; i_d_1++)
+            for(int i_d_0 = 0; i_d_0 < 2; i_d_0++)
             {
               localTensor[((i_ele + n_ele * i_r_0) + 3 * n_ele * i_r_1)] += -1 * c_q0[((i_g + 6 * i_d_0) + 2 * 6 * i_d_1)] * d_CG1[(((i_ele + n_ele * i_d_1) + 2 * n_ele * i_g) + 6 * 2 * n_ele * i_r_0)] * d_CG1[(((i_ele + n_ele * i_d_0) + 2 * n_ele * i_g) + 6 * 2 * n_ele * i_r_1)] * detwei[(i_ele + n_ele * i_g)];
             };
@@ -152,9 +152,9 @@ __global__ void rhs(double* localTensor, int n_ele, double dt, double* detwei, d
       for(int i_g = 0; i_g < 6; i_g++)
       {
         localTensor[(i_ele + n_ele * i_r_0)] += CG1[(i_r_0 + 3 * i_g)] * c_q0[i_g] * detwei[(i_ele + n_ele * i_g)];
-        for(int i_d_0 = 0; i_d_0 < 2; i_d_0++)
+        for(int i_d_3 = 0; i_d_3 < 2; i_d_3++)
         {
-          for(int i_d_1 = 0; i_d_1 < 2; i_d_1++)
+          for(int i_d_0 = 0; i_d_0 < 2; i_d_0++)
           {
             localTensor[(i_ele + n_ele * i_r_0)] += 0.5 * -1 * c_q1[((i_g + 6 * i_d_0) + 2 * 6 * i_d_1)] * d_CG1[(((i_ele + n_ele * i_d_1) + 2 * n_ele * i_g) + 6 * 2 * n_ele * i_r_0)] * d_c_q0[(i_g + 6 * i_d_0)] * detwei[(i_ele + n_ele * i_g)];
           };

--- a/tests/expected/cuda/diffusion-2.cu
+++ b/tests/expected/cuda/diffusion-2.cu
@@ -156,7 +156,7 @@ __global__ void rhs(double* localTensor, int n_ele, double dt, double* detwei, d
         {
           for(int i_d_0 = 0; i_d_0 < 2; i_d_0++)
           {
-            localTensor[(i_ele + n_ele * i_r_0)] += 0.5 * -1 * c_q1[((i_g + 6 * i_d_0) + 2 * 6 * i_d_1)] * d_CG1[(((i_ele + n_ele * i_d_0) + 2 * n_ele * i_g) + 6 * 2 * n_ele * i_r_0)] * d_c_q0[(i_g + 6 * i_d_0)] * detwei[(i_ele + n_ele * i_g)];
+            localTensor[(i_ele + n_ele * i_r_0)] += 0.5 * -1 * c_q1[((i_g + 6 * i_d_0) + 2 * 6 * i_d_1)] * d_CG1[(((i_ele + n_ele * i_d_0) + 2 * n_ele * i_g) + 6 * 2 * n_ele * i_r_0)] * d_c_q0[(i_g + 6 * i_d_3)] * detwei[(i_ele + n_ele * i_g)];
           };
         };
       };

--- a/tests/expected/cuda/diffusion-3.cu
+++ b/tests/expected/cuda/diffusion-3.cu
@@ -27,7 +27,7 @@ __global__ void A(double* localTensor, int n_ele, double dt, double* detwei, dou
         for(int i_g = 0; i_g < 6; i_g++)
         {
           localTensor[((i_ele + n_ele * i_r_0) + 3 * n_ele * i_r_1)] += CG1[(i_r_0 + 3 * i_g)] * CG1[(i_r_1 + 3 * i_g)] * detwei[(i_ele + n_ele * i_g)];
-          for(int i_d_0 = 0; i_d_0 < 2; i_d_0++)
+          for(int i_d_1 = 0; i_d_1 < 2; i_d_1++)
           {
             localTensor[((i_ele + n_ele * i_r_0) + 3 * n_ele * i_r_1)] += -1 * 0.5 * d_CG1[(((i_ele + n_ele * i_d_0) + 2 * n_ele * i_g) + 6 * 2 * n_ele * i_r_0)] * d_CG1[(((i_ele + n_ele * i_d_0) + 2 * n_ele * i_g) + 6 * 2 * n_ele * i_r_1)] * 0.1 * -1 * dt * detwei[(i_ele + n_ele * i_g)];
           };
@@ -48,7 +48,7 @@ __global__ void d(double* localTensor, int n_ele, double dt, double* detwei, dou
         localTensor[((i_ele + n_ele * i_r_0) + 3 * n_ele * i_r_1)] = 0.0;
         for(int i_g = 0; i_g < 6; i_g++)
         {
-          for(int i_d_0 = 0; i_d_0 < 2; i_d_0++)
+          for(int i_d_1 = 0; i_d_1 < 2; i_d_1++)
           {
             localTensor[((i_ele + n_ele * i_r_0) + 3 * n_ele * i_r_1)] += d_CG1[(((i_ele + n_ele * i_d_0) + 2 * n_ele * i_g) + 6 * 2 * n_ele * i_r_0)] * d_CG1[(((i_ele + n_ele * i_d_0) + 2 * n_ele * i_g) + 6 * 2 * n_ele * i_r_1)] * 0.1 * -1 * dt * detwei[(i_ele + n_ele * i_g)];
           };
@@ -104,7 +104,7 @@ __global__ void rhs(double* localTensor, int n_ele, double dt, double* detwei, d
       for(int i_g = 0; i_g < 6; i_g++)
       {
         localTensor[(i_ele + n_ele * i_r_0)] += CG1[(i_r_0 + 3 * i_g)] * c_q0[i_g] * detwei[(i_ele + n_ele * i_g)];
-        for(int i_d_0 = 0; i_d_0 < 2; i_d_0++)
+        for(int i_d_1 = 0; i_d_1 < 2; i_d_1++)
         {
           localTensor[(i_ele + n_ele * i_r_0)] += 0.5 * d_CG1[(((i_ele + n_ele * i_d_0) + 2 * n_ele * i_g) + 6 * 2 * n_ele * i_r_0)] * d_c_q0[(i_g + 6 * i_d_0)] * 0.1 * -1 * dt * detwei[(i_ele + n_ele * i_g)];
         };

--- a/tests/expected/cuda/diffusion-3.cu
+++ b/tests/expected/cuda/diffusion-3.cu
@@ -29,7 +29,7 @@ __global__ void A(double* localTensor, int n_ele, double dt, double* detwei, dou
           localTensor[((i_ele + n_ele * i_r_0) + 3 * n_ele * i_r_1)] += CG1[(i_r_0 + 3 * i_g)] * CG1[(i_r_1 + 3 * i_g)] * detwei[(i_ele + n_ele * i_g)];
           for(int i_d_1 = 0; i_d_1 < 2; i_d_1++)
           {
-            localTensor[((i_ele + n_ele * i_r_0) + 3 * n_ele * i_r_1)] += -1 * 0.5 * d_CG1[(((i_ele + n_ele * i_d_0) + 2 * n_ele * i_g) + 6 * 2 * n_ele * i_r_0)] * d_CG1[(((i_ele + n_ele * i_d_0) + 2 * n_ele * i_g) + 6 * 2 * n_ele * i_r_1)] * 0.1 * -1 * dt * detwei[(i_ele + n_ele * i_g)];
+            localTensor[((i_ele + n_ele * i_r_0) + 3 * n_ele * i_r_1)] += -1 * 0.5 * d_CG1[(((i_ele + n_ele * i_d_1) + 2 * n_ele * i_g) + 6 * 2 * n_ele * i_r_0)] * d_CG1[(((i_ele + n_ele * i_d_1) + 2 * n_ele * i_g) + 6 * 2 * n_ele * i_r_1)] * 0.1 * -1 * dt * detwei[(i_ele + n_ele * i_g)];
           };
         };
       };
@@ -50,7 +50,7 @@ __global__ void d(double* localTensor, int n_ele, double dt, double* detwei, dou
         {
           for(int i_d_1 = 0; i_d_1 < 2; i_d_1++)
           {
-            localTensor[((i_ele + n_ele * i_r_0) + 3 * n_ele * i_r_1)] += d_CG1[(((i_ele + n_ele * i_d_0) + 2 * n_ele * i_g) + 6 * 2 * n_ele * i_r_0)] * d_CG1[(((i_ele + n_ele * i_d_0) + 2 * n_ele * i_g) + 6 * 2 * n_ele * i_r_1)] * 0.1 * -1 * dt * detwei[(i_ele + n_ele * i_g)];
+            localTensor[((i_ele + n_ele * i_r_0) + 3 * n_ele * i_r_1)] += d_CG1[(((i_ele + n_ele * i_d_1) + 2 * n_ele * i_g) + 6 * 2 * n_ele * i_r_0)] * d_CG1[(((i_ele + n_ele * i_d_1) + 2 * n_ele * i_g) + 6 * 2 * n_ele * i_r_1)] * 0.1 * -1 * dt * detwei[(i_ele + n_ele * i_g)];
           };
         };
       };
@@ -91,10 +91,10 @@ __global__ void rhs(double* localTensor, int n_ele, double dt, double* detwei, d
       };
       for(int i_d_0 = 0; i_d_0 < 2; i_d_0++)
       {
-        d_c_q0[(i_g + 6 * i_d_0)] = 0.0;
+        d_c_q0[i_g] = 0.0;
         for(int i_r_0 = 0; i_r_0 < 3; i_r_0++)
         {
-          d_c_q0[(i_g + 6 * i_d_0)] += c0[(i_ele + n_ele * i_r_0)] * d_CG1[(((i_ele + n_ele * i_d_0) + 2 * n_ele * i_g) + 6 * 2 * n_ele * i_r_0)];
+          d_c_q0[i_g] += c0[(i_ele + n_ele * i_r_0)] * d_CG1[(((i_ele + n_ele * i_d_0) + 2 * n_ele * i_g) + 6 * 2 * n_ele * i_r_0)];
         };
       };
     };
@@ -106,7 +106,7 @@ __global__ void rhs(double* localTensor, int n_ele, double dt, double* detwei, d
         localTensor[(i_ele + n_ele * i_r_0)] += CG1[(i_r_0 + 3 * i_g)] * c_q0[i_g] * detwei[(i_ele + n_ele * i_g)];
         for(int i_d_1 = 0; i_d_1 < 2; i_d_1++)
         {
-          localTensor[(i_ele + n_ele * i_r_0)] += 0.5 * d_CG1[(((i_ele + n_ele * i_d_0) + 2 * n_ele * i_g) + 6 * 2 * n_ele * i_r_0)] * d_c_q0[(i_g + 6 * i_d_0)] * 0.1 * -1 * dt * detwei[(i_ele + n_ele * i_g)];
+          localTensor[(i_ele + n_ele * i_r_0)] += 0.5 * d_CG1[(((i_ele + n_ele * i_d_1) + 2 * n_ele * i_g) + 6 * 2 * n_ele * i_r_0)] * d_c_q0[(i_g + 6 * i_d_1)] * 0.1 * -1 * dt * detwei[(i_ele + n_ele * i_g)];
         };
       };
     };

--- a/tests/expected/cuda/diffusion-3.cu
+++ b/tests/expected/cuda/diffusion-3.cu
@@ -91,10 +91,10 @@ __global__ void rhs(double* localTensor, int n_ele, double dt, double* detwei, d
       };
       for(int i_d_0 = 0; i_d_0 < 2; i_d_0++)
       {
-        d_c_q0[i_g] = 0.0;
+        d_c_q0[(i_g + 6 * i_d_0)] = 0.0;
         for(int i_r_0 = 0; i_r_0 < 3; i_r_0++)
         {
-          d_c_q0[i_g] += c0[(i_ele + n_ele * i_r_0)] * d_CG1[(((i_ele + n_ele * i_d_0) + 2 * n_ele * i_g) + 6 * 2 * n_ele * i_r_0)];
+          d_c_q0[(i_g + 6 * i_d_0)] += c0[(i_ele + n_ele * i_r_0)] * d_CG1[(((i_ele + n_ele * i_d_0) + 2 * n_ele * i_g) + 6 * 2 * n_ele * i_r_0)];
         };
       };
     };

--- a/tests/expected/cuda/helmholtz.cu
+++ b/tests/expected/cuda/helmholtz.cu
@@ -27,7 +27,7 @@ __global__ void A(double* localTensor, int n_ele, double dt, double* detwei, dou
         for(int i_g = 0; i_g < 6; i_g++)
         {
           localTensor[((i_ele + n_ele * i_r_0) + 3 * n_ele * i_r_1)] += -1 * CG1[(i_r_0 + 3 * i_g)] * CG1[(i_r_1 + 3 * i_g)] * detwei[(i_ele + n_ele * i_g)];
-          for(int i_d_0 = 0; i_d_0 < 2; i_d_0++)
+          for(int i_d_1 = 0; i_d_1 < 2; i_d_1++)
           {
             localTensor[((i_ele + n_ele * i_r_0) + 3 * n_ele * i_r_1)] += d_CG1[(((i_ele + n_ele * i_d_0) + 2 * n_ele * i_g) + 6 * 2 * n_ele * i_r_0)] * d_CG1[(((i_ele + n_ele * i_d_0) + 2 * n_ele * i_g) + 6 * 2 * n_ele * i_r_1)] * detwei[(i_ele + n_ele * i_g)];
           };

--- a/tests/expected/cuda/helmholtz.cu
+++ b/tests/expected/cuda/helmholtz.cu
@@ -29,7 +29,7 @@ __global__ void A(double* localTensor, int n_ele, double dt, double* detwei, dou
           localTensor[((i_ele + n_ele * i_r_0) + 3 * n_ele * i_r_1)] += -1 * CG1[(i_r_0 + 3 * i_g)] * CG1[(i_r_1 + 3 * i_g)] * detwei[(i_ele + n_ele * i_g)];
           for(int i_d_1 = 0; i_d_1 < 2; i_d_1++)
           {
-            localTensor[((i_ele + n_ele * i_r_0) + 3 * n_ele * i_r_1)] += d_CG1[(((i_ele + n_ele * i_d_0) + 2 * n_ele * i_g) + 6 * 2 * n_ele * i_r_0)] * d_CG1[(((i_ele + n_ele * i_d_0) + 2 * n_ele * i_g) + 6 * 2 * n_ele * i_r_1)] * detwei[(i_ele + n_ele * i_g)];
+            localTensor[((i_ele + n_ele * i_r_0) + 3 * n_ele * i_r_1)] += d_CG1[(((i_ele + n_ele * i_d_1) + 2 * n_ele * i_g) + 6 * 2 * n_ele * i_r_0)] * d_CG1[(((i_ele + n_ele * i_d_1) + 2 * n_ele * i_g) + 6 * 2 * n_ele * i_r_1)] * detwei[(i_ele + n_ele * i_g)];
           };
         };
       };

--- a/tests/expected/cuda/laplacian.cu
+++ b/tests/expected/cuda/laplacian.cu
@@ -26,7 +26,7 @@ __global__ void A(double* localTensor, int n_ele, double dt, double* detwei, dou
         localTensor[((i_ele + n_ele * i_r_0) + 3 * n_ele * i_r_1)] = 0.0;
         for(int i_g = 0; i_g < 6; i_g++)
         {
-          for(int i_d_0 = 0; i_d_0 < 2; i_d_0++)
+          for(int i_d_1 = 0; i_d_1 < 2; i_d_1++)
           {
             localTensor[((i_ele + n_ele * i_r_0) + 3 * n_ele * i_r_1)] += d_CG1[(((i_ele + n_ele * i_d_0) + 2 * n_ele * i_g) + 6 * 2 * n_ele * i_r_0)] * d_CG1[(((i_ele + n_ele * i_d_0) + 2 * n_ele * i_g) + 6 * 2 * n_ele * i_r_1)] * detwei[(i_ele + n_ele * i_g)];
           };

--- a/tests/expected/cuda/laplacian.cu
+++ b/tests/expected/cuda/laplacian.cu
@@ -28,7 +28,7 @@ __global__ void A(double* localTensor, int n_ele, double dt, double* detwei, dou
         {
           for(int i_d_1 = 0; i_d_1 < 2; i_d_1++)
           {
-            localTensor[((i_ele + n_ele * i_r_0) + 3 * n_ele * i_r_1)] += d_CG1[(((i_ele + n_ele * i_d_0) + 2 * n_ele * i_g) + 6 * 2 * n_ele * i_r_0)] * d_CG1[(((i_ele + n_ele * i_d_0) + 2 * n_ele * i_g) + 6 * 2 * n_ele * i_r_1)] * detwei[(i_ele + n_ele * i_g)];
+            localTensor[((i_ele + n_ele * i_r_0) + 3 * n_ele * i_r_1)] += d_CG1[(((i_ele + n_ele * i_d_1) + 2 * n_ele * i_g) + 6 * 2 * n_ele * i_r_0)] * d_CG1[(((i_ele + n_ele * i_d_1) + 2 * n_ele * i_g) + 6 * 2 * n_ele * i_r_1)] * detwei[(i_ele + n_ele * i_g)];
           };
         };
       };

--- a/tests/expected/cuda/simple-advection-diffusion.cu
+++ b/tests/expected/cuda/simple-advection-diffusion.cu
@@ -31,7 +31,7 @@ __global__ void A(double* localTensor, int n_ele, double dt, double* detwei, dou
         for(int i_g = 0; i_g < 6; i_g++)
         {
           localTensor[((i_ele + n_ele * i_r_0) + 3 * n_ele * i_r_1)] += CG1[(i_r_0 + 3 * i_g)] * CG1[(i_r_1 + 3 * i_g)] * detwei[(i_ele + n_ele * i_g)];
-          for(int i_d_0 = 0; i_d_0 < 2; i_d_0++)
+          for(int i_d_1 = 0; i_d_1 < 2; i_d_1++)
           {
             localTensor[((i_ele + n_ele * i_r_0) + 3 * n_ele * i_r_1)] += -1 * 0.5 * d_CG1[(((i_ele + n_ele * i_d_0) + 2 * n_ele * i_g) + 6 * 2 * n_ele * i_r_0)] * d_CG1[(((i_ele + n_ele * i_d_0) + 2 * n_ele * i_g) + 6 * 2 * n_ele * i_r_1)] * 0.1 * -1 * dt * detwei[(i_ele + n_ele * i_g)];
           };
@@ -52,7 +52,7 @@ __global__ void d(double* localTensor, int n_ele, double dt, double* detwei, dou
         localTensor[((i_ele + n_ele * i_r_0) + 3 * n_ele * i_r_1)] = 0.0;
         for(int i_g = 0; i_g < 6; i_g++)
         {
-          for(int i_d_0 = 0; i_d_0 < 2; i_d_0++)
+          for(int i_d_1 = 0; i_d_1 < 2; i_d_1++)
           {
             localTensor[((i_ele + n_ele * i_r_0) + 3 * n_ele * i_r_1)] += d_CG1[(((i_ele + n_ele * i_d_0) + 2 * n_ele * i_g) + 6 * 2 * n_ele * i_r_0)] * d_CG1[(((i_ele + n_ele * i_d_0) + 2 * n_ele * i_g) + 6 * 2 * n_ele * i_r_1)] * 0.1 * -1 * dt * detwei[(i_ele + n_ele * i_g)];
           };
@@ -108,7 +108,7 @@ __global__ void diff_rhs(double* localTensor, int n_ele, double dt, double* detw
       for(int i_g = 0; i_g < 6; i_g++)
       {
         localTensor[(i_ele + n_ele * i_r_0)] += CG1[(i_r_0 + 3 * i_g)] * c_q0[i_g] * detwei[(i_ele + n_ele * i_g)];
-        for(int i_d_0 = 0; i_d_0 < 2; i_d_0++)
+        for(int i_d_1 = 0; i_d_1 < 2; i_d_1++)
         {
           localTensor[(i_ele + n_ele * i_r_0)] += 0.5 * d_CG1[(((i_ele + n_ele * i_d_0) + 2 * n_ele * i_g) + 6 * 2 * n_ele * i_r_0)] * d_c_q0[(i_g + 6 * i_d_0)] * 0.1 * -1 * dt * detwei[(i_ele + n_ele * i_g)];
         };

--- a/tests/expected/cuda/simple-advection-diffusion.cu
+++ b/tests/expected/cuda/simple-advection-diffusion.cu
@@ -95,10 +95,10 @@ __global__ void diff_rhs(double* localTensor, int n_ele, double dt, double* detw
       };
       for(int i_d_0 = 0; i_d_0 < 2; i_d_0++)
       {
-        d_c_q0[i_g] = 0.0;
+        d_c_q0[(i_g + 6 * i_d_0)] = 0.0;
         for(int i_r_0 = 0; i_r_0 < 3; i_r_0++)
         {
-          d_c_q0[i_g] += c0[(i_ele + n_ele * i_r_0)] * d_CG1[(((i_ele + n_ele * i_d_0) + 2 * n_ele * i_g) + 6 * 2 * n_ele * i_r_0)];
+          d_c_q0[(i_g + 6 * i_d_0)] += c0[(i_ele + n_ele * i_r_0)] * d_CG1[(((i_ele + n_ele * i_d_0) + 2 * n_ele * i_g) + 6 * 2 * n_ele * i_r_0)];
         };
       };
     };

--- a/tests/expected/cuda/simple-advection-diffusion.cu
+++ b/tests/expected/cuda/simple-advection-diffusion.cu
@@ -33,7 +33,7 @@ __global__ void A(double* localTensor, int n_ele, double dt, double* detwei, dou
           localTensor[((i_ele + n_ele * i_r_0) + 3 * n_ele * i_r_1)] += CG1[(i_r_0 + 3 * i_g)] * CG1[(i_r_1 + 3 * i_g)] * detwei[(i_ele + n_ele * i_g)];
           for(int i_d_1 = 0; i_d_1 < 2; i_d_1++)
           {
-            localTensor[((i_ele + n_ele * i_r_0) + 3 * n_ele * i_r_1)] += -1 * 0.5 * d_CG1[(((i_ele + n_ele * i_d_0) + 2 * n_ele * i_g) + 6 * 2 * n_ele * i_r_0)] * d_CG1[(((i_ele + n_ele * i_d_0) + 2 * n_ele * i_g) + 6 * 2 * n_ele * i_r_1)] * 0.1 * -1 * dt * detwei[(i_ele + n_ele * i_g)];
+            localTensor[((i_ele + n_ele * i_r_0) + 3 * n_ele * i_r_1)] += -1 * 0.5 * d_CG1[(((i_ele + n_ele * i_d_1) + 2 * n_ele * i_g) + 6 * 2 * n_ele * i_r_0)] * d_CG1[(((i_ele + n_ele * i_d_1) + 2 * n_ele * i_g) + 6 * 2 * n_ele * i_r_1)] * 0.1 * -1 * dt * detwei[(i_ele + n_ele * i_g)];
           };
         };
       };
@@ -54,7 +54,7 @@ __global__ void d(double* localTensor, int n_ele, double dt, double* detwei, dou
         {
           for(int i_d_1 = 0; i_d_1 < 2; i_d_1++)
           {
-            localTensor[((i_ele + n_ele * i_r_0) + 3 * n_ele * i_r_1)] += d_CG1[(((i_ele + n_ele * i_d_0) + 2 * n_ele * i_g) + 6 * 2 * n_ele * i_r_0)] * d_CG1[(((i_ele + n_ele * i_d_0) + 2 * n_ele * i_g) + 6 * 2 * n_ele * i_r_1)] * 0.1 * -1 * dt * detwei[(i_ele + n_ele * i_g)];
+            localTensor[((i_ele + n_ele * i_r_0) + 3 * n_ele * i_r_1)] += d_CG1[(((i_ele + n_ele * i_d_1) + 2 * n_ele * i_g) + 6 * 2 * n_ele * i_r_0)] * d_CG1[(((i_ele + n_ele * i_d_1) + 2 * n_ele * i_g) + 6 * 2 * n_ele * i_r_1)] * 0.1 * -1 * dt * detwei[(i_ele + n_ele * i_g)];
           };
         };
       };
@@ -95,10 +95,10 @@ __global__ void diff_rhs(double* localTensor, int n_ele, double dt, double* detw
       };
       for(int i_d_0 = 0; i_d_0 < 2; i_d_0++)
       {
-        d_c_q0[(i_g + 6 * i_d_0)] = 0.0;
+        d_c_q0[i_g] = 0.0;
         for(int i_r_0 = 0; i_r_0 < 3; i_r_0++)
         {
-          d_c_q0[(i_g + 6 * i_d_0)] += c0[(i_ele + n_ele * i_r_0)] * d_CG1[(((i_ele + n_ele * i_d_0) + 2 * n_ele * i_g) + 6 * 2 * n_ele * i_r_0)];
+          d_c_q0[i_g] += c0[(i_ele + n_ele * i_r_0)] * d_CG1[(((i_ele + n_ele * i_d_0) + 2 * n_ele * i_g) + 6 * 2 * n_ele * i_r_0)];
         };
       };
     };
@@ -110,7 +110,7 @@ __global__ void diff_rhs(double* localTensor, int n_ele, double dt, double* detw
         localTensor[(i_ele + n_ele * i_r_0)] += CG1[(i_r_0 + 3 * i_g)] * c_q0[i_g] * detwei[(i_ele + n_ele * i_g)];
         for(int i_d_1 = 0; i_d_1 < 2; i_d_1++)
         {
-          localTensor[(i_ele + n_ele * i_r_0)] += 0.5 * d_CG1[(((i_ele + n_ele * i_d_0) + 2 * n_ele * i_g) + 6 * 2 * n_ele * i_r_0)] * d_c_q0[(i_g + 6 * i_d_0)] * 0.1 * -1 * dt * detwei[(i_ele + n_ele * i_g)];
+          localTensor[(i_ele + n_ele * i_r_0)] += 0.5 * d_CG1[(((i_ele + n_ele * i_d_1) + 2 * n_ele * i_g) + 6 * 2 * n_ele * i_r_0)] * d_c_q0[(i_g + 6 * i_d_1)] * 0.1 * -1 * dt * detwei[(i_ele + n_ele * i_g)];
         };
       };
     };

--- a/tests/expected/op2/diffusion-1.cpp
+++ b/tests/expected/op2/diffusion-1.cpp
@@ -33,7 +33,7 @@ void A(double localTensor[3][3], double dt, double detwei[6], double c0[2][2][3]
         {
           for(int i_d_0 = 0; i_d_0 < 2; i_d_0++)
           {
-            localTensor[i_r_0][i_r_1] += -1 * 0.5 * c_q0[i_g][i_d_0][i_d_1] * -1 * d_CG1[i_d_1][i_g][i_r_0] * d_CG1[i_d_0][i_g][i_r_1] * detwei[i_g];
+            localTensor[i_r_0][i_r_1] += -1 * 0.5 * c_q0[i_g][i_d_0][i_d_1] * -1 * d_CG1[i_d_0][i_g][i_r_0] * d_CG1[i_d_1][i_g][i_r_1] * detwei[i_g];
           };
         };
       };
@@ -69,7 +69,7 @@ void d(double localTensor[3][3], double dt, double detwei[6], double c0[2][2][3]
         {
           for(int i_d_0 = 0; i_d_0 < 2; i_d_0++)
           {
-            localTensor[i_r_0][i_r_1] += c_q0[i_g][i_d_0][i_d_1] * -1 * d_CG1[i_d_1][i_g][i_r_0] * d_CG1[i_d_0][i_g][i_r_1] * detwei[i_g];
+            localTensor[i_r_0][i_r_1] += c_q0[i_g][i_d_0][i_d_1] * -1 * d_CG1[i_d_0][i_g][i_r_0] * d_CG1[i_d_1][i_g][i_r_1] * detwei[i_g];
           };
         };
       };
@@ -134,7 +134,7 @@ void rhs(double localTensor[3], double dt, double detwei[6], double c0[3], doubl
       {
         for(int i_d_0 = 0; i_d_0 < 2; i_d_0++)
         {
-          localTensor[i_r_0] += 0.5 * c_q1[i_g][i_d_0][i_d_1] * -1 * d_CG1[i_d_1][i_g][i_r_0] * d_c_q0[i_g][i_d_0] * detwei[i_g];
+          localTensor[i_r_0] += 0.5 * c_q1[i_g][i_d_0][i_d_1] * -1 * d_CG1[i_d_0][i_g][i_r_0] * d_c_q0[i_g][i_d_0] * detwei[i_g];
         };
       };
     };

--- a/tests/expected/op2/diffusion-1.cpp
+++ b/tests/expected/op2/diffusion-1.cpp
@@ -29,9 +29,9 @@ void A(double localTensor[3][3], double dt, double detwei[6], double c0[2][2][3]
       for(int i_g = 0; i_g < 6; i_g++)
       {
         localTensor[i_r_0][i_r_1] += CG1[i_r_0][i_g] * CG1[i_r_1][i_g] * detwei[i_g];
-        for(int i_d_0 = 0; i_d_0 < 2; i_d_0++)
+        for(int i_d_1 = 0; i_d_1 < 2; i_d_1++)
         {
-          for(int i_d_1 = 0; i_d_1 < 2; i_d_1++)
+          for(int i_d_0 = 0; i_d_0 < 2; i_d_0++)
           {
             localTensor[i_r_0][i_r_1] += -1 * 0.5 * c_q0[i_g][i_d_0][i_d_1] * -1 * d_CG1[i_d_1][i_g][i_r_0] * d_CG1[i_d_0][i_g][i_r_1] * detwei[i_g];
           };
@@ -65,9 +65,9 @@ void d(double localTensor[3][3], double dt, double detwei[6], double c0[2][2][3]
       localTensor[i_r_0][i_r_1] = 0.0;
       for(int i_g = 0; i_g < 6; i_g++)
       {
-        for(int i_d_0 = 0; i_d_0 < 2; i_d_0++)
+        for(int i_d_1 = 0; i_d_1 < 2; i_d_1++)
         {
-          for(int i_d_1 = 0; i_d_1 < 2; i_d_1++)
+          for(int i_d_0 = 0; i_d_0 < 2; i_d_0++)
           {
             localTensor[i_r_0][i_r_1] += c_q0[i_g][i_d_0][i_d_1] * -1 * d_CG1[i_d_1][i_g][i_r_0] * d_CG1[i_d_0][i_g][i_r_1] * detwei[i_g];
           };
@@ -130,9 +130,9 @@ void rhs(double localTensor[3], double dt, double detwei[6], double c0[3], doubl
     for(int i_g = 0; i_g < 6; i_g++)
     {
       localTensor[i_r_0] += CG1[i_r_0][i_g] * c_q0[i_g] * detwei[i_g];
-      for(int i_d_0 = 0; i_d_0 < 2; i_d_0++)
+      for(int i_d_1 = 0; i_d_1 < 2; i_d_1++)
       {
-        for(int i_d_1 = 0; i_d_1 < 2; i_d_1++)
+        for(int i_d_0 = 0; i_d_0 < 2; i_d_0++)
         {
           localTensor[i_r_0] += 0.5 * c_q1[i_g][i_d_0][i_d_1] * -1 * d_CG1[i_d_1][i_g][i_r_0] * d_c_q0[i_g][i_d_0] * detwei[i_g];
         };

--- a/tests/expected/op2/diffusion-1.cpp
+++ b/tests/expected/op2/diffusion-1.cpp
@@ -134,7 +134,7 @@ void rhs(double localTensor[3], double dt, double detwei[6], double c0[3], doubl
       {
         for(int i_d_0 = 0; i_d_0 < 2; i_d_0++)
         {
-          localTensor[i_r_0] += 0.5 * c_q1[i_g][i_d_0][i_d_1] * -1 * d_CG1[i_d_0][i_g][i_r_0] * d_c_q0[i_g][i_d_0] * detwei[i_g];
+          localTensor[i_r_0] += 0.5 * c_q1[i_g][i_d_0][i_d_1] * -1 * d_CG1[i_d_0][i_g][i_r_0] * d_c_q0[i_g][i_d_1] * detwei[i_g];
         };
       };
     };

--- a/tests/expected/op2/diffusion-2.cpp
+++ b/tests/expected/op2/diffusion-2.cpp
@@ -33,7 +33,7 @@ void A(double localTensor[3][3], double dt, double detwei[6], double c0[2][2][3]
         {
           for(int i_d_0 = 0; i_d_0 < 2; i_d_0++)
           {
-            localTensor[i_r_0][i_r_1] += -1 * 0.5 * -1 * c_q0[i_g][i_d_0][i_d_1] * d_CG1[i_d_1][i_g][i_r_0] * d_CG1[i_d_0][i_g][i_r_1] * detwei[i_g];
+            localTensor[i_r_0][i_r_1] += -1 * 0.5 * -1 * c_q0[i_g][i_d_0][i_d_1] * d_CG1[i_d_0][i_g][i_r_0] * d_CG1[i_d_3][i_g][i_r_1] * detwei[i_g];
           };
         };
       };
@@ -69,7 +69,7 @@ void d(double localTensor[3][3], double dt, double detwei[6], double c0[2][2][3]
         {
           for(int i_d_0 = 0; i_d_0 < 2; i_d_0++)
           {
-            localTensor[i_r_0][i_r_1] += -1 * c_q0[i_g][i_d_0][i_d_1] * d_CG1[i_d_1][i_g][i_r_0] * d_CG1[i_d_0][i_g][i_r_1] * detwei[i_g];
+            localTensor[i_r_0][i_r_1] += -1 * c_q0[i_g][i_d_0][i_d_1] * d_CG1[i_d_0][i_g][i_r_0] * d_CG1[i_d_3][i_g][i_r_1] * detwei[i_g];
           };
         };
       };
@@ -134,7 +134,7 @@ void rhs(double localTensor[3], double dt, double detwei[6], double c0[3], doubl
       {
         for(int i_d_0 = 0; i_d_0 < 2; i_d_0++)
         {
-          localTensor[i_r_0] += 0.5 * -1 * c_q1[i_g][i_d_0][i_d_1] * d_CG1[i_d_1][i_g][i_r_0] * d_c_q0[i_g][i_d_0] * detwei[i_g];
+          localTensor[i_r_0] += 0.5 * -1 * c_q1[i_g][i_d_0][i_d_1] * d_CG1[i_d_0][i_g][i_r_0] * d_c_q0[i_g][i_d_0] * detwei[i_g];
         };
       };
     };

--- a/tests/expected/op2/diffusion-2.cpp
+++ b/tests/expected/op2/diffusion-2.cpp
@@ -134,7 +134,7 @@ void rhs(double localTensor[3], double dt, double detwei[6], double c0[3], doubl
       {
         for(int i_d_0 = 0; i_d_0 < 2; i_d_0++)
         {
-          localTensor[i_r_0] += 0.5 * -1 * c_q1[i_g][i_d_0][i_d_1] * d_CG1[i_d_0][i_g][i_r_0] * d_c_q0[i_g][i_d_0] * detwei[i_g];
+          localTensor[i_r_0] += 0.5 * -1 * c_q1[i_g][i_d_0][i_d_1] * d_CG1[i_d_0][i_g][i_r_0] * d_c_q0[i_g][i_d_3] * detwei[i_g];
         };
       };
     };

--- a/tests/expected/op2/diffusion-2.cpp
+++ b/tests/expected/op2/diffusion-2.cpp
@@ -29,9 +29,9 @@ void A(double localTensor[3][3], double dt, double detwei[6], double c0[2][2][3]
       for(int i_g = 0; i_g < 6; i_g++)
       {
         localTensor[i_r_0][i_r_1] += CG1[i_r_0][i_g] * CG1[i_r_1][i_g] * detwei[i_g];
-        for(int i_d_0 = 0; i_d_0 < 2; i_d_0++)
+        for(int i_d_3 = 0; i_d_3 < 2; i_d_3++)
         {
-          for(int i_d_1 = 0; i_d_1 < 2; i_d_1++)
+          for(int i_d_0 = 0; i_d_0 < 2; i_d_0++)
           {
             localTensor[i_r_0][i_r_1] += -1 * 0.5 * -1 * c_q0[i_g][i_d_0][i_d_1] * d_CG1[i_d_1][i_g][i_r_0] * d_CG1[i_d_0][i_g][i_r_1] * detwei[i_g];
           };
@@ -65,9 +65,9 @@ void d(double localTensor[3][3], double dt, double detwei[6], double c0[2][2][3]
       localTensor[i_r_0][i_r_1] = 0.0;
       for(int i_g = 0; i_g < 6; i_g++)
       {
-        for(int i_d_0 = 0; i_d_0 < 2; i_d_0++)
+        for(int i_d_3 = 0; i_d_3 < 2; i_d_3++)
         {
-          for(int i_d_1 = 0; i_d_1 < 2; i_d_1++)
+          for(int i_d_0 = 0; i_d_0 < 2; i_d_0++)
           {
             localTensor[i_r_0][i_r_1] += -1 * c_q0[i_g][i_d_0][i_d_1] * d_CG1[i_d_1][i_g][i_r_0] * d_CG1[i_d_0][i_g][i_r_1] * detwei[i_g];
           };
@@ -130,9 +130,9 @@ void rhs(double localTensor[3], double dt, double detwei[6], double c0[3], doubl
     for(int i_g = 0; i_g < 6; i_g++)
     {
       localTensor[i_r_0] += CG1[i_r_0][i_g] * c_q0[i_g] * detwei[i_g];
-      for(int i_d_0 = 0; i_d_0 < 2; i_d_0++)
+      for(int i_d_3 = 0; i_d_3 < 2; i_d_3++)
       {
-        for(int i_d_1 = 0; i_d_1 < 2; i_d_1++)
+        for(int i_d_0 = 0; i_d_0 < 2; i_d_0++)
         {
           localTensor[i_r_0] += 0.5 * -1 * c_q1[i_g][i_d_0][i_d_1] * d_CG1[i_d_1][i_g][i_r_0] * d_c_q0[i_g][i_d_0] * detwei[i_g];
         };

--- a/tests/expected/op2/diffusion-3.cpp
+++ b/tests/expected/op2/diffusion-3.cpp
@@ -71,10 +71,10 @@ void rhs(double localTensor[3], double dt, double detwei[6], double c0[3], doubl
       };
       for(int i_d_0 = 0; i_d_0 < 2; i_d_0++)
       {
-        d_c_q0[i_g] = 0.0;
+        d_c_q0[i_g][i_d_0] = 0.0;
         for(int i_r_0 = 0; i_r_0 < 3; i_r_0++)
         {
-          d_c_q0[i_g] += c0[i_r_0] * d_CG1[i_d_0][i_g][i_r_0];
+          d_c_q0[i_g][i_d_0] += c0[i_r_0] * d_CG1[i_d_0][i_g][i_r_0];
         };
       };
     };

--- a/tests/expected/op2/diffusion-3.cpp
+++ b/tests/expected/op2/diffusion-3.cpp
@@ -16,7 +16,7 @@ void A(double localTensor[3][3], double dt, double detwei[6], double CG1[3][6], 
         localTensor[i_r_0][i_r_1] += CG1[i_r_0][i_g] * CG1[i_r_1][i_g] * detwei[i_g];
         for(int i_d_1 = 0; i_d_1 < 2; i_d_1++)
         {
-          localTensor[i_r_0][i_r_1] += -1 * 0.5 * d_CG1[i_d_0][i_g][i_r_0] * d_CG1[i_d_0][i_g][i_r_1] * 0.1 * -1 * dt * detwei[i_g];
+          localTensor[i_r_0][i_r_1] += -1 * 0.5 * d_CG1[i_d_1][i_g][i_r_0] * d_CG1[i_d_1][i_g][i_r_1] * 0.1 * -1 * dt * detwei[i_g];
         };
       };
     };
@@ -34,7 +34,7 @@ void d(double localTensor[3][3], double dt, double detwei[6], double d_CG1[2][6]
       {
         for(int i_d_1 = 0; i_d_1 < 2; i_d_1++)
         {
-          localTensor[i_r_0][i_r_1] += d_CG1[i_d_0][i_g][i_r_0] * d_CG1[i_d_0][i_g][i_r_1] * 0.1 * -1 * dt * detwei[i_g];
+          localTensor[i_r_0][i_r_1] += d_CG1[i_d_1][i_g][i_r_0] * d_CG1[i_d_1][i_g][i_r_1] * 0.1 * -1 * dt * detwei[i_g];
         };
       };
     };
@@ -71,10 +71,10 @@ void rhs(double localTensor[3], double dt, double detwei[6], double c0[3], doubl
       };
       for(int i_d_0 = 0; i_d_0 < 2; i_d_0++)
       {
-        d_c_q0[i_g][i_d_0] = 0.0;
+        d_c_q0[i_g] = 0.0;
         for(int i_r_0 = 0; i_r_0 < 3; i_r_0++)
         {
-          d_c_q0[i_g][i_d_0] += c0[i_r_0] * d_CG1[i_d_0][i_g][i_r_0];
+          d_c_q0[i_g] += c0[i_r_0] * d_CG1[i_d_0][i_g][i_r_0];
         };
       };
     };
@@ -84,7 +84,7 @@ void rhs(double localTensor[3], double dt, double detwei[6], double c0[3], doubl
       localTensor[i_r_0] += CG1[i_r_0][i_g] * c_q0[i_g] * detwei[i_g];
       for(int i_d_1 = 0; i_d_1 < 2; i_d_1++)
       {
-        localTensor[i_r_0] += 0.5 * d_CG1[i_d_0][i_g][i_r_0] * d_c_q0[i_g][i_d_0] * 0.1 * -1 * dt * detwei[i_g];
+        localTensor[i_r_0] += 0.5 * d_CG1[i_d_1][i_g][i_r_0] * d_c_q0[i_g][i_d_1] * 0.1 * -1 * dt * detwei[i_g];
       };
     };
   };

--- a/tests/expected/op2/diffusion-3.cpp
+++ b/tests/expected/op2/diffusion-3.cpp
@@ -14,7 +14,7 @@ void A(double localTensor[3][3], double dt, double detwei[6], double CG1[3][6], 
       for(int i_g = 0; i_g < 6; i_g++)
       {
         localTensor[i_r_0][i_r_1] += CG1[i_r_0][i_g] * CG1[i_r_1][i_g] * detwei[i_g];
-        for(int i_d_0 = 0; i_d_0 < 2; i_d_0++)
+        for(int i_d_1 = 0; i_d_1 < 2; i_d_1++)
         {
           localTensor[i_r_0][i_r_1] += -1 * 0.5 * d_CG1[i_d_0][i_g][i_r_0] * d_CG1[i_d_0][i_g][i_r_1] * 0.1 * -1 * dt * detwei[i_g];
         };
@@ -32,7 +32,7 @@ void d(double localTensor[3][3], double dt, double detwei[6], double d_CG1[2][6]
       localTensor[i_r_0][i_r_1] = 0.0;
       for(int i_g = 0; i_g < 6; i_g++)
       {
-        for(int i_d_0 = 0; i_d_0 < 2; i_d_0++)
+        for(int i_d_1 = 0; i_d_1 < 2; i_d_1++)
         {
           localTensor[i_r_0][i_r_1] += d_CG1[i_d_0][i_g][i_r_0] * d_CG1[i_d_0][i_g][i_r_1] * 0.1 * -1 * dt * detwei[i_g];
         };
@@ -82,7 +82,7 @@ void rhs(double localTensor[3], double dt, double detwei[6], double c0[3], doubl
     for(int i_g = 0; i_g < 6; i_g++)
     {
       localTensor[i_r_0] += CG1[i_r_0][i_g] * c_q0[i_g] * detwei[i_g];
-      for(int i_d_0 = 0; i_d_0 < 2; i_d_0++)
+      for(int i_d_1 = 0; i_d_1 < 2; i_d_1++)
       {
         localTensor[i_r_0] += 0.5 * d_CG1[i_d_0][i_g][i_r_0] * d_c_q0[i_g][i_d_0] * 0.1 * -1 * dt * detwei[i_g];
       };

--- a/tests/expected/op2/helmholtz.cpp
+++ b/tests/expected/op2/helmholtz.cpp
@@ -14,7 +14,7 @@ void A(double localTensor[3][3], double dt, double detwei[6], double CG1[3][6], 
       for(int i_g = 0; i_g < 6; i_g++)
       {
         localTensor[i_r_0][i_r_1] += -1 * CG1[i_r_0][i_g] * CG1[i_r_1][i_g] * detwei[i_g];
-        for(int i_d_0 = 0; i_d_0 < 2; i_d_0++)
+        for(int i_d_1 = 0; i_d_1 < 2; i_d_1++)
         {
           localTensor[i_r_0][i_r_1] += d_CG1[i_d_0][i_g][i_r_0] * d_CG1[i_d_0][i_g][i_r_1] * detwei[i_g];
         };

--- a/tests/expected/op2/helmholtz.cpp
+++ b/tests/expected/op2/helmholtz.cpp
@@ -16,7 +16,7 @@ void A(double localTensor[3][3], double dt, double detwei[6], double CG1[3][6], 
         localTensor[i_r_0][i_r_1] += -1 * CG1[i_r_0][i_g] * CG1[i_r_1][i_g] * detwei[i_g];
         for(int i_d_1 = 0; i_d_1 < 2; i_d_1++)
         {
-          localTensor[i_r_0][i_r_1] += d_CG1[i_d_0][i_g][i_r_0] * d_CG1[i_d_0][i_g][i_r_1] * detwei[i_g];
+          localTensor[i_r_0][i_r_1] += d_CG1[i_d_1][i_g][i_r_0] * d_CG1[i_d_1][i_g][i_r_1] * detwei[i_g];
         };
       };
     };

--- a/tests/expected/op2/laplacian.cpp
+++ b/tests/expected/op2/laplacian.cpp
@@ -13,7 +13,7 @@ void A(double localTensor[3][3], double dt, double detwei[6], double d_CG1[2][6]
       localTensor[i_r_0][i_r_1] = 0.0;
       for(int i_g = 0; i_g < 6; i_g++)
       {
-        for(int i_d_0 = 0; i_d_0 < 2; i_d_0++)
+        for(int i_d_1 = 0; i_d_1 < 2; i_d_1++)
         {
           localTensor[i_r_0][i_r_1] += d_CG1[i_d_0][i_g][i_r_0] * d_CG1[i_d_0][i_g][i_r_1] * detwei[i_g];
         };

--- a/tests/expected/op2/laplacian.cpp
+++ b/tests/expected/op2/laplacian.cpp
@@ -15,7 +15,7 @@ void A(double localTensor[3][3], double dt, double detwei[6], double d_CG1[2][6]
       {
         for(int i_d_1 = 0; i_d_1 < 2; i_d_1++)
         {
-          localTensor[i_r_0][i_r_1] += d_CG1[i_d_0][i_g][i_r_0] * d_CG1[i_d_0][i_g][i_r_1] * detwei[i_g];
+          localTensor[i_r_0][i_r_1] += d_CG1[i_d_1][i_g][i_r_0] * d_CG1[i_d_1][i_g][i_r_1] * detwei[i_g];
         };
       };
     };

--- a/tests/expected/op2/simple-advection-diffusion.cpp
+++ b/tests/expected/op2/simple-advection-diffusion.cpp
@@ -71,10 +71,10 @@ void diff_rhs(double localTensor[3], double dt, double detwei[6], double c0[3], 
       };
       for(int i_d_0 = 0; i_d_0 < 2; i_d_0++)
       {
-        d_c_q0[i_g] = 0.0;
+        d_c_q0[i_g][i_d_0] = 0.0;
         for(int i_r_0 = 0; i_r_0 < 3; i_r_0++)
         {
-          d_c_q0[i_g] += c0[i_r_0] * d_CG1[i_d_0][i_g][i_r_0];
+          d_c_q0[i_g][i_d_0] += c0[i_r_0] * d_CG1[i_d_0][i_g][i_r_0];
         };
       };
     };

--- a/tests/expected/op2/simple-advection-diffusion.cpp
+++ b/tests/expected/op2/simple-advection-diffusion.cpp
@@ -16,7 +16,7 @@ void A(double localTensor[3][3], double dt, double detwei[6], double CG1[3][6], 
         localTensor[i_r_0][i_r_1] += CG1[i_r_0][i_g] * CG1[i_r_1][i_g] * detwei[i_g];
         for(int i_d_1 = 0; i_d_1 < 2; i_d_1++)
         {
-          localTensor[i_r_0][i_r_1] += -1 * 0.5 * d_CG1[i_d_0][i_g][i_r_0] * d_CG1[i_d_0][i_g][i_r_1] * 0.1 * -1 * dt * detwei[i_g];
+          localTensor[i_r_0][i_r_1] += -1 * 0.5 * d_CG1[i_d_1][i_g][i_r_0] * d_CG1[i_d_1][i_g][i_r_1] * 0.1 * -1 * dt * detwei[i_g];
         };
       };
     };
@@ -34,7 +34,7 @@ void d(double localTensor[3][3], double dt, double detwei[6], double d_CG1[2][6]
       {
         for(int i_d_1 = 0; i_d_1 < 2; i_d_1++)
         {
-          localTensor[i_r_0][i_r_1] += d_CG1[i_d_0][i_g][i_r_0] * d_CG1[i_d_0][i_g][i_r_1] * 0.1 * -1 * dt * detwei[i_g];
+          localTensor[i_r_0][i_r_1] += d_CG1[i_d_1][i_g][i_r_0] * d_CG1[i_d_1][i_g][i_r_1] * 0.1 * -1 * dt * detwei[i_g];
         };
       };
     };
@@ -71,10 +71,10 @@ void diff_rhs(double localTensor[3], double dt, double detwei[6], double c0[3], 
       };
       for(int i_d_0 = 0; i_d_0 < 2; i_d_0++)
       {
-        d_c_q0[i_g][i_d_0] = 0.0;
+        d_c_q0[i_g] = 0.0;
         for(int i_r_0 = 0; i_r_0 < 3; i_r_0++)
         {
-          d_c_q0[i_g][i_d_0] += c0[i_r_0] * d_CG1[i_d_0][i_g][i_r_0];
+          d_c_q0[i_g] += c0[i_r_0] * d_CG1[i_d_0][i_g][i_r_0];
         };
       };
     };
@@ -84,7 +84,7 @@ void diff_rhs(double localTensor[3], double dt, double detwei[6], double c0[3], 
       localTensor[i_r_0] += CG1[i_r_0][i_g] * c_q0[i_g] * detwei[i_g];
       for(int i_d_1 = 0; i_d_1 < 2; i_d_1++)
       {
-        localTensor[i_r_0] += 0.5 * d_CG1[i_d_0][i_g][i_r_0] * d_c_q0[i_g][i_d_0] * 0.1 * -1 * dt * detwei[i_g];
+        localTensor[i_r_0] += 0.5 * d_CG1[i_d_1][i_g][i_r_0] * d_c_q0[i_g][i_d_1] * 0.1 * -1 * dt * detwei[i_g];
       };
     };
   };

--- a/tests/expected/op2/simple-advection-diffusion.cpp
+++ b/tests/expected/op2/simple-advection-diffusion.cpp
@@ -14,7 +14,7 @@ void A(double localTensor[3][3], double dt, double detwei[6], double CG1[3][6], 
       for(int i_g = 0; i_g < 6; i_g++)
       {
         localTensor[i_r_0][i_r_1] += CG1[i_r_0][i_g] * CG1[i_r_1][i_g] * detwei[i_g];
-        for(int i_d_0 = 0; i_d_0 < 2; i_d_0++)
+        for(int i_d_1 = 0; i_d_1 < 2; i_d_1++)
         {
           localTensor[i_r_0][i_r_1] += -1 * 0.5 * d_CG1[i_d_0][i_g][i_r_0] * d_CG1[i_d_0][i_g][i_r_1] * 0.1 * -1 * dt * detwei[i_g];
         };
@@ -32,7 +32,7 @@ void d(double localTensor[3][3], double dt, double detwei[6], double d_CG1[2][6]
       localTensor[i_r_0][i_r_1] = 0.0;
       for(int i_g = 0; i_g < 6; i_g++)
       {
-        for(int i_d_0 = 0; i_d_0 < 2; i_d_0++)
+        for(int i_d_1 = 0; i_d_1 < 2; i_d_1++)
         {
           localTensor[i_r_0][i_r_1] += d_CG1[i_d_0][i_g][i_r_0] * d_CG1[i_d_0][i_g][i_r_1] * 0.1 * -1 * dt * detwei[i_g];
         };
@@ -82,7 +82,7 @@ void diff_rhs(double localTensor[3], double dt, double detwei[6], double c0[3], 
     for(int i_g = 0; i_g < 6; i_g++)
     {
       localTensor[i_r_0] += CG1[i_r_0][i_g] * c_q0[i_g] * detwei[i_g];
-      for(int i_d_0 = 0; i_d_0 < 2; i_d_0++)
+      for(int i_d_1 = 0; i_d_1 < 2; i_d_1++)
       {
         localTensor[i_r_0] += 0.5 * d_CG1[i_d_0][i_g][i_r_0] * d_c_q0[i_g][i_d_0] * 0.1 * -1 * dt * detwei[i_g];
       };


### PR DESCRIPTION
Change the assignment of indices in the generated code. They were previously statically assigned based on the count of IndexSum nodes in the UFL AST, which is only going to work for the limited and simple set of forms that we are working with now.

In this branch, Indices are assigned based on the relevant UFL Index objects and their count in the AST.
