### PR TITLE
Fix index construction

### DIFF
--- a/mcfc/cudaexpression.py
+++ b/mcfc/cudaexpression.py
@@ -140,20 +140,22 @@ class CudaQuadratureExpressionBuilder(QuadratureExpressionBuilder):
         elif isinstance(tree, SpatialDerivative):
             element = tree.operands()[0].element()
         
+        dim = element.cell().topological_dimension()
         rank = tree.rank()
         indices = [ ElementIndex() ]
         for r in range(rank):
-            indices.append(self._formBackend.buildDimIndex(r))
+            indices.append(buildDimIndex(r,dim))
         indices.append(buildBasisIndex(0, element))
         return indices
 
     def subscript_spatial_derivative(self, tree):
         element = tree.operands()[0].element()
+        dim = element.cell().topological_dimension()
         # The count of the basis function induction variable is always
         # 0 in the quadrature loops (i.e. i_r_0), and only the first dim
         # index should be used to subscript the derivative (I think).
         indices = [ ElementIndex(),
-                    self._formBackend.buildDimIndex(0),
+                    buildDimIndex(0, dim),
                     self._formBackend.buildGaussIndex(),
                     buildBasisIndex(0, element) ]
         return indices

--- a/mcfc/cudaexpression.py
+++ b/mcfc/cudaexpression.py
@@ -95,7 +95,7 @@ class CudaExpressionBuilder(ExpressionBuilder):
         for dimIndices in self._indexStack:
             indices.extend(dimIndices)
         indices += [buildBasisIndex(count, element), 
-                    self._formBackend.buildGaussIndex()]
+                    buildGaussIndex(self._formBackend.numGaussPoints)]
         return indices
 
     def subscript_SpatialDerivative(self,tree,dimIndices):
@@ -108,10 +108,10 @@ class CudaExpressionBuilder(ExpressionBuilder):
         if isinstance(operand, Argument):
             indices = [ ElementIndex()]
             indices.extend(dimIndices)
-            indices = indices + [ self._formBackend.buildGaussIndex(),
+            indices = indices + [ buildGaussIndex(self._formBackend.numGaussPoints),
                                   buildBasisIndex(count, element) ]
         elif isinstance(operand, Coefficient):
-            indices = [ self._formBackend.buildGaussIndex() ]
+            indices = [ buildGaussIndex(self._formBackend.numGaussPoints) ]
             indices.extend(dimIndices)
 
         return indices
@@ -156,7 +156,7 @@ class CudaQuadratureExpressionBuilder(QuadratureExpressionBuilder):
         # index should be used to subscript the derivative (I think).
         indices = [ ElementIndex(),
                     buildDimIndex(0, dim),
-                    self._formBackend.buildGaussIndex(),
+                    buildGaussIndex(self._formBackend.numGaussPoints),
                     buildBasisIndex(0, element) ]
         return indices
 

--- a/mcfc/cudaform.py
+++ b/mcfc/cudaform.py
@@ -55,7 +55,7 @@ class CudaFormBackend(FormBackend):
         return KPG.generate(tree, form, statutoryParameters)
 
     def subscript_detwei(self):
-        indices = [ElementIndex(), self.buildGaussIndex()]
+        indices = [ElementIndex(), buildGaussIndex(self.numGaussPoints)]
         return indices
 
 # vim:sw=4:ts=4:sts=4:et

--- a/mcfc/expression.py
+++ b/mcfc/expression.py
@@ -18,7 +18,6 @@
 # holders.
 
 from form import *
-from formutils import buildBasisIndex
 from symbolicvalue import SymbolicValue
 from ufl.argument import TrialFunction
 from ufl.coefficient import Coefficient
@@ -153,14 +152,15 @@ class ExpressionBuilder(Transformer):
         rank = coeff.rank()
         if isinstance(coeff, Coefficient):
             name = buildCoefficientQuadName(coeff)
-            dim = coeff.element().cell().topological_dimension()
+            element = coeff.element()
         else:
             # The spatial derivative adds an extra dim index so we need to
             # bump up the rank
             rank = rank + 1
             name = buildSpatialDerivativeName(coeff)
-            dim = coeff.operands()[0].element().cell().topological_dimension()
+            element = coeff.operands()[0].element()
         base = Variable(name)
+        dim = element.cell().topological_dimension()
         
         # If there are no indices present (e.g. in the quadrature evaluation loop) then
         # we need to fake indices for the coefficient based on its rank:

--- a/mcfc/expression.py
+++ b/mcfc/expression.py
@@ -18,6 +18,7 @@
 # holders.
 
 from form import *
+from formutils import buildBasisIndex
 from symbolicvalue import SymbolicValue
 from ufl.argument import TrialFunction
 from ufl.coefficient import Coefficient
@@ -229,9 +230,15 @@ class QuadratureExpressionBuilder:
         raise NotImplementedError("You're supposed to implement subscript()!")
 
     def subscript_argument(self, tree):
+        # FIXME: At present we make use of the scalar basis for the expression
+        # even if the coefficient is on a vector or tensor basis. So we need to
+        # extract a single element to use as the basis.
+        e = tree.element()
+        if isinstance(e, (VectorElement, TensorElement)):
+            e = e.sub_elements()[0]
         # The count of the basis function induction variable is always
         # 0 in the quadrature loops (i.e. i_r_0)
-        indices = [self._formBackend.buildBasisIndex(0),
+        indices = [buildBasisIndex(0, e),
                    self._formBackend.buildGaussIndex()]
         return indices
 

--- a/mcfc/expression.py
+++ b/mcfc/expression.py
@@ -55,7 +55,8 @@ class ExpressionBuilder(Transformer):
 
     def subscript_CoeffQuadrature(self, coeff):
         # Build the subscript based on the rank
-        indices = [self._formBackend.buildGaussIndex()]
+        indices = [buildGaussIndex(self._formBackend.numGaussPoints)]
+
         rank = coeff.rank()
 
         if isinstance(coeff, SpatialDerivative):
@@ -242,7 +243,7 @@ class QuadratureExpressionBuilder:
         # The count of the basis function induction variable is always
         # 0 in the quadrature loops (i.e. i_r_0)
         indices = [buildBasisIndex(0, e),
-                   self._formBackend.buildGaussIndex()]
+                   buildGaussIndex(self._formBackend.numGaussPoints)]
         return indices
 
     def subscript_spatial_derivative(self, tree):

--- a/mcfc/form.py
+++ b/mcfc/form.py
@@ -98,18 +98,6 @@ class FormBackend(object):
 
         return kernel
 
-    def buildBasisIndex(self, count):
-        "Build index for a loop over basis function values."
-        return BasisIndex(self.numNodesPerEle, count)
-
-    def buildDimIndex(self, count):
-        "Build index for a loop over spatial dimensions."
-        return DimIndex(self.numDimensions, count)
-
-    def buildConstDimIndex(self, count):
-        "Build literal subscript for a loop over spatial dimensions."
-        return ConstIndex(self.numDimensions, count)
-
     def buildGaussIndex(self):
         "Build index for a Gauss quadrature loop."
         return GaussIndex(self.numGaussPoints)

--- a/mcfc/form.py
+++ b/mcfc/form.py
@@ -98,10 +98,6 @@ class FormBackend(object):
 
         return kernel
 
-    def buildGaussIndex(self):
-        "Build index for a Gauss quadrature loop."
-        return GaussIndex(self.numGaussPoints)
-
     def buildExpression(self, form, tree):
         "Build the expression represented by the subtree tree of form."
         # Build the rhs expression

--- a/mcfc/form.py
+++ b/mcfc/form.py
@@ -132,21 +132,21 @@ class FormBackend(object):
     def buildLoopNest(self, form):
         "Build the loop nest for evaluating a form expression."
         rank = form.form_data().rank
-        numBasisFunctions = self._numBasisFunctions(form)
+        numBFs = numBasisFunctions(form)
 
         # FIXME what if we have multiple integrals?
         integrand = form.integrals()[0].integrand()
 
         # Build the loop over the first rank, which always exists
         indVarName = self.buildBasisIndex(0).name()
-        loop = buildSimpleForLoop(indVarName, numBasisFunctions)
+        loop = buildSimpleForLoop(indVarName, numBFs)
         outerLoop = loop
 
         # Add another loop for each rank of the form (probably no
         # more than one more... )
         for r in range(1,rank):
             indVarName = self.buildBasisIndex(r).name()
-            basisLoop = buildSimpleForLoop(indVarName, numBasisFunctions)
+            basisLoop = buildSimpleForLoop(indVarName, numBFs)
             loop.append(basisLoop)
             loop = basisLoop
 
@@ -262,14 +262,6 @@ class FormBackend(object):
             declarations.append(decl)
 
         return declarations
-
-    # This function provides a simple calculation of the number of basis
-    # functions per element. This works for the tensor product of a scalar basis
-    # only.
-    def _numBasisFunctions(self, form):
-        elementRank = formElementRank(form)
-        spaceDimension = formElementSpaceDim(form)
-        return self.numNodesPerEle * pow(spaceDimension, elementRank)
 
     def _buildBasisTensors(self, form_data):
         """When using a basis that is a tensor product of the scalar basis, we

--- a/mcfc/form.py
+++ b/mcfc/form.py
@@ -141,7 +141,7 @@ class FormBackend(object):
             loop = basisLoop
 
         # Add a loop for the quadrature
-        indVarName = self.buildGaussIndex().name()
+        indVarName = buildGaussIndex(self.numGaussPoints).name()
         gaussLoop = buildSimpleForLoop(indVarName, self.numGaussPoints)
         loop.append(gaussLoop)
         loop = gaussLoop
@@ -206,7 +206,7 @@ class FormBackend(object):
         coefficients, spatialDerivatives = self._coefficientUseFinder.find(integrand)
 
         # Outer loop over gauss points
-        indVar = self.buildGaussIndex().name()
+        indVar = buildGaussIndex(self.numGaussPoints).name()
         gaussLoop = buildSimpleForLoop(indVar, self.numGaussPoints)
 
         # Build a loop nest for each coefficient containing expressions

--- a/mcfc/form.py
+++ b/mcfc/form.py
@@ -25,7 +25,7 @@ from ufl.finiteelement import FiniteElement, VectorElement, TensorElement
 # MCFC libs
 from codegeneration import *
 from formutils import *
-from utilities import uniqify, formElementRank, formElementSpaceDim
+from utilities import uniqify
 
 class FormBackend(object):
     "Base class for generating form tabulation kernels."

--- a/mcfc/form.py
+++ b/mcfc/form.py
@@ -25,6 +25,7 @@ from ufl.finiteelement import FiniteElement, VectorElement, TensorElement
 # MCFC libs
 from codegeneration import *
 from formutils import *
+from utilities import uniqify, formElementRank, formElementSpaceDim
 
 class FormBackend(object):
     "Base class for generating form tabulation kernels."
@@ -262,32 +263,12 @@ class FormBackend(object):
 
         return declarations
 
-    def _elementRank(self, form):
-        # Use the element from the first argument, which should be the TestFunction
-        arg = form.form_data().arguments[0]
-        e = arg.element()
-
-        if isinstance(e, FiniteElement):
-            return 0
-        elif isinstance(e, VectorElement):
-            return 1
-        elif isinstance(e, TensorElement):
-            return 2
-        else:
-            raise RuntimeError("Not a recognised element.")
-
-    def _elementSpaceDim(self, form):
-        # Use the element from the first argument, which should be the TestFunction
-        arg = form.form_data().arguments[0]
-        e = arg.element()
-        return e.cell().geometric_dimension()
-
     # This function provides a simple calculation of the number of basis
     # functions per element. This works for the tensor product of a scalar basis
     # only.
     def _numBasisFunctions(self, form):
-        elementRank = self._elementRank(form)
-        spaceDimension = self._elementSpaceDim(form)
+        elementRank = formElementRank(form)
+        spaceDimension = formElementSpaceDim(form)
         return self.numNodesPerEle * pow(spaceDimension, elementRank)
 
     def _buildBasisTensors(self, form_data):

--- a/mcfc/formutils.py
+++ b/mcfc/formutils.py
@@ -23,6 +23,8 @@
 from ufl.argument import Argument
 from ufl.coefficient import Coefficient
 from ufl.algorithms.transformations import Transformer
+from ufl.finiteelement import FiniteElement, VectorElement, TensorElement
+
 # MCFC libs
 from codegeneration import *
 from utilities import uniqify
@@ -232,5 +234,27 @@ def buildTensorArgumentName(tree):
 
 def buildTensorSpatialDerivativeName(tree):
     return buildSpatialDerivativeName(tree) + "_t"
+
+# Used by both the assembler generator and the form generator.
+
+def formElementRank(form):
+    # Use the element from the first argument, which should be the TestFunction
+    arg = form.form_data().arguments[0]
+    e = arg.element()
+
+    if isinstance(e, FiniteElement):
+        return 0
+    elif isinstance(e, VectorElement):
+        return 1
+    elif isinstance(e, TensorElement):
+        return 2
+    else:
+        raise RuntimeError("Not a recognised element.")
+
+def formElementSpaceDim(form):
+    # Use the element from the first argument, which should be the TestFunction
+    arg = form.form_data().arguments[0]
+    e = arg.element()
+    return e.cell().geometric_dimension()
 
 # vim:sw=4:ts=4:sts=4:et

--- a/mcfc/formutils.py
+++ b/mcfc/formutils.py
@@ -191,9 +191,9 @@ class ConstIndex(CodeIndex):
 
 # Index builders
 
-def buildBasisIndex(count, element):
+def buildBasisIndex(count, e):
     "Build index for a loop over basis function values."
-    return BasisIndex(numBasisFunctions(element), count)
+    return BasisIndex(numBasisFunctions(e), count)
 
 def buildDimIndex(count, e):
     "Build index for a loop over spatial dimensions."
@@ -264,7 +264,9 @@ def buildTensorSpatialDerivativeName(tree):
 
 # This function provides a simple calculation of the number of basis
 # functions per element. This works for the tensor product of a scalar basis
-# only.
+# only. 
+# It takes a form or an element - if a form is given, it uses the element of
+# the test function.
 def numBasisFunctions(e):
     if isinstance(e, Form):
         # Use the element from the first argument, which should be the TestFunction

--- a/mcfc/formutils.py
+++ b/mcfc/formutils.py
@@ -240,21 +240,17 @@ def buildTensorSpatialDerivativeName(tree):
 def formElementRank(form):
     # Use the element from the first argument, which should be the TestFunction
     arg = form.form_data().arguments[0]
-    e = arg.element()
+    return elementRank(arg.element())
 
-    if isinstance(e, FiniteElement):
-        return 0
-    elif isinstance(e, VectorElement):
-        return 1
-    elif isinstance(e, TensorElement):
-        return 2
-    else:
-        raise RuntimeError("Not a recognised element.")
+def elementRank(e):
+    return len(e.value_shape())
 
 def formElementSpaceDim(form):
     # Use the element from the first argument, which should be the TestFunction
     arg = form.form_data().arguments[0]
-    e = arg.element()
+    return elementSpaceDim(arg.element())
+
+def elementSpaceDim(e):
     return e.cell().geometric_dimension()
 
 # vim:sw=4:ts=4:sts=4:et

--- a/mcfc/formutils.py
+++ b/mcfc/formutils.py
@@ -262,12 +262,9 @@ def buildTensorArgumentName(tree):
 def buildTensorSpatialDerivativeName(tree):
     return buildSpatialDerivativeName(tree) + "_t"
 
-# This function provides a simple calculation of the number of basis
-# functions per element. This works for the tensor product of a scalar basis
-# only. 
-# It takes a form or an element - if a form is given, it uses the element of
-# the test function.
 def numBasisFunctions(e):
+    """Return the number of basis functions. e can be a form or an element - 
+    if e is a form, the element from the test function is used."""
     if isinstance(e, Form):
         # Use the element from the first argument, which should be the TestFunction
         e = e.form_data().arguments[0].element()
@@ -276,11 +273,5 @@ def numBasisFunctions(e):
         return len(element.entity_dofs()) * element.num_components()
     else:
         return element.get_nodal_basis().get_num_members()
-
-def elementRank(e):
-    return len(e.value_shape())
-
-def elementSpaceDim(e):
-    return e.cell().geometric_dimension()
 
 # vim:sw=4:ts=4:sts=4:et

--- a/mcfc/formutils.py
+++ b/mcfc/formutils.py
@@ -273,7 +273,6 @@ def numBasisFunctions(e):
     if isinstance(element, FFCMixedElement):
         return len(element.entity_dofs()) * element.num_components()
     else:
-        print element.get_nodal_basis()
         return element.get_nodal_basis().get_num_members()
 
 def elementRank(e):

--- a/mcfc/formutils.py
+++ b/mcfc/formutils.py
@@ -184,6 +184,28 @@ class ConstIndex(CodeIndex):
     def name(self):
         return str(self._count)
 
+# Index builders
+
+def buildBasisIndex(count, element):
+    "Build index for a loop over basis function values."
+    return BasisIndex(elementRank(element), count)
+
+def buildDimIndex(count, e):
+    "Build index for a loop over spatial dimensions."
+    if isinstance(e, int):
+        dim = e
+    else:
+        dim = elementSpaceDim(e)
+    return DimIndex(dim, count)
+
+def buildConstDimIndex(value, extent):
+    "Build literal subscript for a loop over spatial dimensions."
+    return ConstIndex(extent, count)
+
+def buildGaussIndex(n):
+    "Build index for a Gauss quadrature loop."
+    return GaussIndex(n)
+
 # Name builders
 
 def safe_shortstr(name):

--- a/mcfc/op2expression.py
+++ b/mcfc/op2expression.py
@@ -93,15 +93,16 @@ class Op2QuadratureExpressionBuilder(QuadratureExpressionBuilder):
         # Subscript order: basis index followed by dimension indices (if any)
         indices = [buildBasisIndex(0, element)]
         for r in range(rank):
-            indices.append(self._formBackend.buildDimIndex(r))
+            indices.append(buildDimIndex(r,dim))
         return indices
 
     def subscript_spatial_derivative(self, tree):
         element = tree.operands()[0].element()
+        dim = element.cell().topological_dimension()
         # The count of the basis function induction variable is always
         # 0 in the quadrature loops (i.e. i_r_0), and only the first dim
         # index should be used to subscript the derivative (I think).
-        indices = [ self._formBackend.buildDimIndex(0),
+        indices = [ buildDimIndex(0,dim),
                     self._formBackend.buildGaussIndex(),
                     buildBasisIndex(0, element) ]
         return indices

--- a/mcfc/op2expression.py
+++ b/mcfc/op2expression.py
@@ -45,7 +45,7 @@ class Op2ExpressionBuilder(ExpressionBuilder):
         count = tree.count()
         element = tree.element()
         indices = [buildBasisIndex(count, element),
-                   self._formBackend.buildGaussIndex()]
+                   buildGaussIndex(self._formBackend.numGaussPoints)]
         return indices
 
     def subscript_SpatialDerivative(self,tree,dimIndices):
@@ -58,10 +58,10 @@ class Op2ExpressionBuilder(ExpressionBuilder):
         if isinstance(operand, Argument):
             indices = []
             indices.extend(dimIndices)
-            indices = indices + [ self._formBackend.buildGaussIndex(),
+            indices = indices + [ buildGaussIndex(self._formBackend.numGaussPoints),
                                   buildBasisIndex(count, element) ]
         elif isinstance(operand, Coefficient):
-            indices = [ self._formBackend.buildGaussIndex() ]
+            indices = [ buildGaussIndex(self._formBackend.numGaussPoints) ]
             indices.extend(dimIndices)
 
         return indices
@@ -103,7 +103,7 @@ class Op2QuadratureExpressionBuilder(QuadratureExpressionBuilder):
         # 0 in the quadrature loops (i.e. i_r_0), and only the first dim
         # index should be used to subscript the derivative (I think).
         indices = [ buildDimIndex(0,dim),
-                    self._formBackend.buildGaussIndex(),
+                    buildGaussIndex(self._formBackend.numGaussPoints),
                     buildBasisIndex(0, element) ]
         return indices
 

--- a/mcfc/op2form.py
+++ b/mcfc/op2form.py
@@ -46,7 +46,7 @@ class Op2FormBackend(FormBackend):
         return KPG.generate(tree, form, statutoryParameters)
 
     def subscript_detwei(self):
-        indices = [self.buildGaussIndex()]
+        indices = [buildGaussIndex(self.numGaussPoints)]
         return indices
 
 # vim:sw=4:ts=4:sts=4:et

--- a/mcfc/utilities.py
+++ b/mcfc/utilities.py
@@ -1,5 +1,3 @@
-from ufl.finiteelement import FiniteElement, VectorElement, TensorElement
-
 # From http://www.peterbe.com/plog/uniqifiers-benchmark. This is version f5.
 def uniqify_list(seq, idfun=None):
     idfun = idfun or (lambda x: x)
@@ -40,28 +38,6 @@ def uniqify_rec(seq, idfun=None, seen=None):
             if marker in seen: continue
             seen[marker] = 1
             yield item
-
-# Used by both the assembler generator and the form generator.
-
-def formElementRank(form):
-    # Use the element from the first argument, which should be the TestFunction
-    arg = form.form_data().arguments[0]
-    e = arg.element()
-
-    if isinstance(e, FiniteElement):
-        return 0
-    elif isinstance(e, VectorElement):
-        return 1
-    elif isinstance(e, TensorElement):
-        return 2
-    else:
-        raise RuntimeError("Not a recognised element.")
-
-def formElementSpaceDim(form):
-    # Use the element from the first argument, which should be the TestFunction
-    arg = form.form_data().arguments[0]
-    e = arg.element()
-    return e.cell().geometric_dimension()
 
 # From http://ipython.scipy.org/doc/manual/html/interactive/reference.html#embedding-ipython
 #

--- a/mcfc/utilities.py
+++ b/mcfc/utilities.py
@@ -1,3 +1,5 @@
+from ufl.finiteelement import FiniteElement, VectorElement, TensorElement
+
 # From http://www.peterbe.com/plog/uniqifiers-benchmark. This is version f5.
 def uniqify_list(seq, idfun=None):
     idfun = idfun or (lambda x: x)
@@ -38,6 +40,28 @@ def uniqify_rec(seq, idfun=None, seen=None):
             if marker in seen: continue
             seen[marker] = 1
             yield item
+
+# Used by both the assembler generator and the form generator.
+
+def formElementRank(form):
+    # Use the element from the first argument, which should be the TestFunction
+    arg = form.form_data().arguments[0]
+    e = arg.element()
+
+    if isinstance(e, FiniteElement):
+        return 0
+    elif isinstance(e, VectorElement):
+        return 1
+    elif isinstance(e, TensorElement):
+        return 2
+    else:
+        raise RuntimeError("Not a recognised element.")
+
+def formElementSpaceDim(form):
+    # Use the element from the first argument, which should be the TestFunction
+    arg = form.form_data().arguments[0]
+    e = arg.element()
+    return e.cell().geometric_dimension()
 
 # From http://ipython.scipy.org/doc/manual/html/interactive/reference.html#embedding-ipython
 #

--- a/tests/expected/cuda/identity-vector.cu
+++ b/tests/expected/cuda/identity-vector.cu
@@ -24,12 +24,12 @@ __global__ void A(double* localTensor, int n_ele, double dt, double* detwei, dou
     {
       for(int i_r_1 = 0; i_r_1 < 6; i_r_1++)
       {
-        localTensor[((i_ele + n_ele * i_r_0) + 3 * n_ele * i_r_1)] = 0.0;
+        localTensor[((i_ele + n_ele * i_r_0) + 6 * n_ele * i_r_1)] = 0.0;
         for(int i_g = 0; i_g < 6; i_g++)
         {
           for(int i_d_0 = 0; i_d_0 < 2; i_d_0++)
           {
-            localTensor[((i_ele + n_ele * i_r_0) + 3 * n_ele * i_r_1)] += CG1_v[i_d_0][i_r_0][i_g] * CG1_v[i_d_0][i_r_1][i_g] * detwei[(i_ele + n_ele * i_g)];
+            localTensor[((i_ele + n_ele * i_r_0) + 6 * n_ele * i_r_1)] += CG1_v[i_d_0][i_r_0][i_g] * CG1_v[i_d_0][i_r_1][i_g] * detwei[(i_ele + n_ele * i_g)];
           };
         };
       };

--- a/tests/expected/op2/diffusion-1.cpp
+++ b/tests/expected/op2/diffusion-1.cpp
@@ -4,7 +4,7 @@
 
 
 
-void A(double localTensor[3][3], double dt, double detwei[6], double c0[3][2][2], double CG1[3][6], double d_CG1[2][6][3])
+void A(double localTensor[3][3], double dt, double detwei[6], double c0[12][2][2], double CG1[3][6], double d_CG1[2][6][3])
 {
   double c_q0[6][2][2];
   for(int i_g = 0; i_g < 6; i_g++)
@@ -41,7 +41,7 @@ void A(double localTensor[3][3], double dt, double detwei[6], double c0[3][2][2]
   };
 }
 
-void d(double localTensor[3][3], double dt, double detwei[6], double c0[3][2][2], double d_CG1[2][6][3])
+void d(double localTensor[3][3], double dt, double detwei[6], double c0[12][2][2], double d_CG1[2][6][3])
 {
   double c_q0[6][2][2];
   for(int i_g = 0; i_g < 6; i_g++)
@@ -92,7 +92,7 @@ void M(double localTensor[3][3], double dt, double detwei[6], double CG1[3][6])
   };
 }
 
-void rhs(double localTensor[3], double dt, double detwei[6], double c0[3], double c1[3][2][2], double CG1[3][6], double d_CG1[2][6][3])
+void rhs(double localTensor[3], double dt, double detwei[6], double c0[3], double c1[12][2][2], double CG1[3][6], double d_CG1[2][6][3])
 {
   double c_q0[6];
   double c_q1[6][2][2];

--- a/tests/expected/op2/diffusion-2.cpp
+++ b/tests/expected/op2/diffusion-2.cpp
@@ -4,7 +4,7 @@
 
 
 
-void A(double localTensor[3][3], double dt, double detwei[6], double c0[3][2][2], double CG1[3][6], double d_CG1[2][6][3])
+void A(double localTensor[3][3], double dt, double detwei[6], double c0[12][2][2], double CG1[3][6], double d_CG1[2][6][3])
 {
   double c_q0[6][2][2];
   for(int i_g = 0; i_g < 6; i_g++)
@@ -41,7 +41,7 @@ void A(double localTensor[3][3], double dt, double detwei[6], double c0[3][2][2]
   };
 }
 
-void d(double localTensor[3][3], double dt, double detwei[6], double c0[3][2][2], double d_CG1[2][6][3])
+void d(double localTensor[3][3], double dt, double detwei[6], double c0[12][2][2], double d_CG1[2][6][3])
 {
   double c_q0[6][2][2];
   for(int i_g = 0; i_g < 6; i_g++)
@@ -92,7 +92,7 @@ void M(double localTensor[3][3], double dt, double detwei[6], double CG1[3][6])
   };
 }
 
-void rhs(double localTensor[3], double dt, double detwei[6], double c0[3], double c1[3][2][2], double CG1[3][6], double d_CG1[2][6][3])
+void rhs(double localTensor[3], double dt, double detwei[6], double c0[3], double c1[12][2][2], double CG1[3][6], double d_CG1[2][6][3])
 {
   double c_q0[6];
   double c_q1[6][2][2];

--- a/tests/expected/op2/euler-advection.cpp
+++ b/tests/expected/op2/euler-advection.cpp
@@ -19,7 +19,7 @@ void Mass(double localTensor[3][3], double dt, double detwei[6], double CG1[3][6
   };
 }
 
-void rhs(double localTensor[3], double dt, double detwei[6], double c0[3], double c1[3][2], double CG1[3][6], double d_CG1[2][6][3])
+void rhs(double localTensor[3], double dt, double detwei[6], double c0[3], double c1[6][2], double CG1[3][6], double d_CG1[2][6][3])
 {
   double c_q0[6];
   double c_q1[6][2];

--- a/tests/expected/op2/identity-vector.cpp
+++ b/tests/expected/op2/identity-vector.cpp
@@ -4,7 +4,7 @@
 
 
 
-void A(double localTensor[3][3], double dt, double detwei[6], double CG1[3][6])
+void A(double localTensor[6][6], double dt, double detwei[6], double CG1[3][6])
 {
   double CG1_v[2][6][6] = { { { CG1[0], CG1[6], CG1[12], 0.0, 0.0, 0.0 }, { CG1[1], CG1[7], CG1[13], 0.0, 0.0, 0.0 }, { CG1[2], CG1[8], CG1[14], 0.0, 0.0, 0.0 }, { CG1[3], CG1[9], CG1[15], 0.0, 0.0, 0.0 }, { CG1[4], CG1[10], CG1[16], 0.0, 0.0, 0.0 }, { CG1[5], CG1[11], CG1[17], 0.0, 0.0, 0.0 } }, { { 0.0, 0.0, 0.0, CG1[0], CG1[6], CG1[12] }, { 0.0, 0.0, 0.0, CG1[1], CG1[7], CG1[13] }, { 0.0, 0.0, 0.0, CG1[2], CG1[8], CG1[14] }, { 0.0, 0.0, 0.0, CG1[3], CG1[9], CG1[15] }, { 0.0, 0.0, 0.0, CG1[4], CG1[10], CG1[16] }, { 0.0, 0.0, 0.0, CG1[5], CG1[11], CG1[17] } } };
   for(int i_r_0 = 0; i_r_0 < 6; i_r_0++)
@@ -23,7 +23,7 @@ void A(double localTensor[3][3], double dt, double detwei[6], double CG1[3][6])
   };
 }
 
-void RHS(double localTensor[3], double dt, double detwei[6], double c0[3][2], double CG1[3][6])
+void RHS(double localTensor[6], double dt, double detwei[6], double c0[6][2], double CG1[3][6])
 {
   double CG1_v[2][6][6] = { { { CG1[0], CG1[6], CG1[12], 0.0, 0.0, 0.0 }, { CG1[1], CG1[7], CG1[13], 0.0, 0.0, 0.0 }, { CG1[2], CG1[8], CG1[14], 0.0, 0.0, 0.0 }, { CG1[3], CG1[9], CG1[15], 0.0, 0.0, 0.0 }, { CG1[4], CG1[10], CG1[16], 0.0, 0.0, 0.0 }, { CG1[5], CG1[11], CG1[17], 0.0, 0.0, 0.0 } }, { { 0.0, 0.0, 0.0, CG1[0], CG1[6], CG1[12] }, { 0.0, 0.0, 0.0, CG1[1], CG1[7], CG1[13] }, { 0.0, 0.0, 0.0, CG1[2], CG1[8], CG1[14] }, { 0.0, 0.0, 0.0, CG1[3], CG1[9], CG1[15] }, { 0.0, 0.0, 0.0, CG1[4], CG1[10], CG1[16] }, { 0.0, 0.0, 0.0, CG1[5], CG1[11], CG1[17] } } };
   double c_q0[6][2];

--- a/tests/expected/op2/simple-advection-diffusion.cpp
+++ b/tests/expected/op2/simple-advection-diffusion.cpp
@@ -90,7 +90,7 @@ void diff_rhs(double localTensor[3], double dt, double detwei[6], double c0[3], 
   };
 }
 
-void adv_rhs(double localTensor[3], double dt, double detwei[6], double c0[3], double c1[3][2], double CG1[3][6], double d_CG1[2][6][3])
+void adv_rhs(double localTensor[3], double dt, double detwei[6], double c0[3], double c1[6][2], double CG1[3][6], double d_CG1[2][6][3])
 {
   double c_q0[6];
   double c_q1[6][2];

--- a/tests/inputs/ufl/shallow-water.ufl
+++ b/tests/inputs/ufl/shallow-water.ufl
@@ -1,6 +1,10 @@
 # FIXME: this isn't updated for coefficients in state yet
-V = state.vector_fields["Velocity"] # Velocity space
-H = state.scalar_fields["Height"] # Height space
+v = state.vector_fields["Velocity"] # Velocity space
+h = state.scalar_fields["Height"] # Height space
+
+V = v.element()
+H = h.element()
+
 W = V*H                                # Mixed space of both.
 
 (v, q) = TestFunctions(W)
@@ -28,7 +32,8 @@ A_r=M_u+M_h-0.5*dt*(C+Ct+F)                  # Right hand side form
 rhs=action(A_r,fluidstate)
 
 # Solve the shallow water equations.
-(Vnew, Hnew) =  split(solve(A, rhs))
+new_state =  solve(A, rhs)
 
-state.scalar_fields["Height"] = Hnew
-state.vector_fields["Velocity"] = Vnew
+# How do we get Hnew and Vnew from new_state?
+#state.scalar_fields["Height"] = Hnew
+#state.vector_fields["Velocity"] = Vnew


### PR DESCRIPTION
Summary of changes:

Move buildBasisIndex, buildDimIndex, buildConstDimIndex and buildGaussIndex into formutils and remove all references to the methods with the same names in the FormBackend class. This breaks the link between forms and expressions through indices.

There are still some hard-coded assumptions about the number of dimensions, basis functions and gauss points. However, these changes make it easier to remove them as the index construction is no longer tied to the form backend.

The shallow-water.ufl input file is also modified here - although it was untested, it didn't even parse before. It now parses correctly so we can at least use it with the visualiser.
