### PR TITLE
Only transfer data back to the host when necessary

### DIFF
--- a/fluidity/ufl_program.F90
+++ b/fluidity/ufl_program.F90
@@ -76,12 +76,13 @@ program ufl_program
   call initialise_diagnostics(simulation_name, state)
   call initialise_write_state()
 
+  call initialise_gpu
+  
   ! Always output the initial conditions.
   call output_state(state, current_time, dt, timestep)
 
   call ETIME(tarray, start)
 
-  call initialise_gpu
 
   timestep_loop: do 
     timestep=timestep+1
@@ -99,13 +100,13 @@ program ufl_program
 
   end do timestep_loop
   
-  call finalise_gpu
-
   call ETIME(tarray, finish)
   print *,"Simulation time: ",(finish-start)
 
   ! One last dump
   call output_state(state, current_time, dt, timestep)
+  
+  call finalise_gpu
 
 contains
 

--- a/fluidity/ufl_program.F90
+++ b/fluidity/ufl_program.F90
@@ -89,8 +89,6 @@ program ufl_program
      
     call run_model(dt)
 
-    call calculate_diagnostic_variables(state)
-
     if (simulation_completed(current_time, timestep)) exit timestep_loop     
 
     call advance_current_time(current_time, dt)
@@ -181,6 +179,7 @@ contains
 
     integer, save :: dump_no=0
 
+    call return_fields
     call calculate_diagnostic_variables(state, exclude_nonrecalculated = .false.)
     call write_diagnostics(state, current_time, dt, timestep)
     call write_state(dump_no, state)

--- a/mcfc/cudaassembler.py
+++ b/mcfc/cudaassembler.py
@@ -307,6 +307,10 @@ class CudaAssemblerBackend(AssemblerBackend):
             expand = CudaKernelCall('expand_data', params, gridXDim, blockXDim)
             func.append(expand)
 
+        return func
+
+    def buildReturnFields(self):
+
         # Transfer all fields solved for on the GPU and written back to state
         for field in self._eq.getReturnedFieldNames():
             # Sanity check: only copy back fields that were solved for
@@ -315,7 +319,6 @@ class CudaAssemblerBackend(AssemblerBackend):
                 returnCall = FunctionCall('returnFieldToHost', params)
                 func.append(ArrowOp(state, returnCall))
 
-        return func
 
     def extractCoefficient(self, func, coefficientName):
         varName = coefficientName + 'Coeff'

--- a/mcfc/cudaassembler.py
+++ b/mcfc/cudaassembler.py
@@ -82,6 +82,8 @@ class CudaAssemblerBackend(AssemblerBackend):
         declarations.append(finaliser)
         runModel = self._buildRunModel()
         declarations.append(runModel)
+        returnFields = self._buildReturnFields()
+        declarations.append(returnFields)
 
         # Build definitions
         # This comes last since it requires information from earlier steps
@@ -309,8 +311,10 @@ class CudaAssemblerBackend(AssemblerBackend):
 
         return func
 
-    def buildReturnFields(self):
+    def _buildReturnFields(self):
 
+        func = FunctionDefinition(Void(), 'return_fields_', [])
+        func.setExternC(True)
         # Transfer all fields solved for on the GPU and written back to state
         for field in self._eq.getReturnedFieldNames():
             # Sanity check: only copy back fields that were solved for
@@ -319,6 +323,7 @@ class CudaAssemblerBackend(AssemblerBackend):
                 returnCall = FunctionCall('returnFieldToHost', params)
                 func.append(ArrowOp(state, returnCall))
 
+        return func
 
     def extractCoefficient(self, func, coefficientName):
         varName = coefficientName + 'Coeff'

--- a/tests/expected/cuda/diffusion-1/model.cu
+++ b/tests/expected/cuda/diffusion-1/model.cu
@@ -420,7 +420,6 @@ extern "C" void run_model_(double* dt_pointer)
   vector_addto<<<gridXDim,blockXDim>>>(globalVector, eleNodes, localVector, numEle, nodesPerEle);
   cg_solve(Tracer_findrm, Tracer_findrm_size, Tracer_colm, Tracer_colm_size, globalMatrix, globalVector, numNodes, solutionVector);
   expand_data<<<gridXDim,blockXDim>>>(TracerCoeff, solutionVector, eleNodes, numEle, state->getValsPerNode("Tracer"), nodesPerEle);
-  state->returnFieldToHost("Tracer");
 }
 
 

--- a/tests/expected/cuda/diffusion-1/model.cu
+++ b/tests/expected/cuda/diffusion-1/model.cu
@@ -422,5 +422,10 @@ extern "C" void run_model_(double* dt_pointer)
   expand_data<<<gridXDim,blockXDim>>>(TracerCoeff, solutionVector, eleNodes, numEle, state->getValsPerNode("Tracer"), nodesPerEle);
 }
 
+extern "C" void return_fields_()
+{
+  state->returnFieldToHost("Tracer");
+}
+
 
 

--- a/tests/expected/cuda/diffusion-2/model.cu
+++ b/tests/expected/cuda/diffusion-2/model.cu
@@ -420,7 +420,6 @@ extern "C" void run_model_(double* dt_pointer)
   vector_addto<<<gridXDim,blockXDim>>>(globalVector, eleNodes, localVector, numEle, nodesPerEle);
   cg_solve(Tracer_findrm, Tracer_findrm_size, Tracer_colm, Tracer_colm_size, globalMatrix, globalVector, numNodes, solutionVector);
   expand_data<<<gridXDim,blockXDim>>>(TracerCoeff, solutionVector, eleNodes, numEle, state->getValsPerNode("Tracer"), nodesPerEle);
-  state->returnFieldToHost("Tracer");
 }
 
 

--- a/tests/expected/cuda/diffusion-2/model.cu
+++ b/tests/expected/cuda/diffusion-2/model.cu
@@ -422,5 +422,10 @@ extern "C" void run_model_(double* dt_pointer)
   expand_data<<<gridXDim,blockXDim>>>(TracerCoeff, solutionVector, eleNodes, numEle, state->getValsPerNode("Tracer"), nodesPerEle);
 }
 
+extern "C" void return_fields_()
+{
+  state->returnFieldToHost("Tracer");
+}
+
 
 

--- a/tests/expected/cuda/diffusion-3/FluidTracer.cu
+++ b/tests/expected/cuda/diffusion-3/FluidTracer.cu
@@ -379,7 +379,6 @@ extern "C" void run_model_(double* dt_pointer)
   vector_addto<<<gridXDim,blockXDim>>>(globalVector, eleNodes, localVector, numEle, nodesPerEle);
   cg_solve(Tracer_findrm, Tracer_findrm_size, Tracer_colm, Tracer_colm_size, globalMatrix, globalVector, numNodes, solutionVector);
   expand_data<<<gridXDim,blockXDim>>>(TracerCoeff, solutionVector, eleNodes, numEle, state->getValsPerNode("Tracer"), nodesPerEle);
-  state->returnFieldToHost("Tracer");
 }
 
 

--- a/tests/expected/cuda/diffusion-3/FluidTracer.cu
+++ b/tests/expected/cuda/diffusion-3/FluidTracer.cu
@@ -381,5 +381,10 @@ extern "C" void run_model_(double* dt_pointer)
   expand_data<<<gridXDim,blockXDim>>>(TracerCoeff, solutionVector, eleNodes, numEle, state->getValsPerNode("Tracer"), nodesPerEle);
 }
 
+extern "C" void return_fields_()
+{
+  state->returnFieldToHost("Tracer");
+}
+
 
 

--- a/tests/expected/cuda/euler-advection/FluidTracer.cu
+++ b/tests/expected/cuda/euler-advection/FluidTracer.cu
@@ -217,7 +217,6 @@ extern "C" void run_model_(double* dt_pointer)
   vector_addto<<<gridXDim,blockXDim>>>(globalVector, eleNodes, localVector, numEle, nodesPerEle);
   cg_solve(Tracer_findrm, Tracer_findrm_size, Tracer_colm, Tracer_colm_size, globalMatrix, globalVector, numNodes, solutionVector);
   expand_data<<<gridXDim,blockXDim>>>(TracerCoeff, solutionVector, eleNodes, numEle, state->getValsPerNode("Tracer"), nodesPerEle);
-  state->returnFieldToHost("Tracer");
 }
 
 

--- a/tests/expected/cuda/euler-advection/FluidTracer.cu
+++ b/tests/expected/cuda/euler-advection/FluidTracer.cu
@@ -219,5 +219,10 @@ extern "C" void run_model_(double* dt_pointer)
   expand_data<<<gridXDim,blockXDim>>>(TracerCoeff, solutionVector, eleNodes, numEle, state->getValsPerNode("Tracer"), nodesPerEle);
 }
 
+extern "C" void return_fields_()
+{
+  state->returnFieldToHost("Tracer");
+}
+
 
 

--- a/tests/expected/cuda/helmholtz/FluidTracer.cu
+++ b/tests/expected/cuda/helmholtz/FluidTracer.cu
@@ -210,7 +210,6 @@ extern "C" void run_model_(double* dt_pointer)
   vector_addto<<<gridXDim,blockXDim>>>(globalVector, eleNodes, localVector, numEle, nodesPerEle);
   cg_solve(Tracer_findrm, Tracer_findrm_size, Tracer_colm, Tracer_colm_size, globalMatrix, globalVector, numNodes, solutionVector);
   expand_data<<<gridXDim,blockXDim>>>(TracerCoeff, solutionVector, eleNodes, numEle, state->getValsPerNode("Tracer"), nodesPerEle);
-  state->returnFieldToHost("Tracer");
 }
 
 

--- a/tests/expected/cuda/helmholtz/FluidTracer.cu
+++ b/tests/expected/cuda/helmholtz/FluidTracer.cu
@@ -212,5 +212,10 @@ extern "C" void run_model_(double* dt_pointer)
   expand_data<<<gridXDim,blockXDim>>>(TracerCoeff, solutionVector, eleNodes, numEle, state->getValsPerNode("Tracer"), nodesPerEle);
 }
 
+extern "C" void return_fields_()
+{
+  state->returnFieldToHost("Tracer");
+}
+
 
 

--- a/tests/expected/cuda/identity-vector/model.cu
+++ b/tests/expected/cuda/identity-vector/model.cu
@@ -260,5 +260,10 @@ extern "C" void run_model_(double* dt_pointer)
   expand_data<<<gridXDim,blockXDim>>>(VelocityCoeff, solutionVector, eleNodes, numEle, state->getValsPerNode("Velocity"), nodesPerEle);
 }
 
+extern "C" void return_fields_()
+{
+  state->returnFieldToHost("Velocity");
+}
+
 
 

--- a/tests/expected/cuda/identity-vector/model.cu
+++ b/tests/expected/cuda/identity-vector/model.cu
@@ -258,7 +258,6 @@ extern "C" void run_model_(double* dt_pointer)
   vector_addto<<<gridXDim,blockXDim>>>(globalVector, eleNodes, localVector, numEle, nodesPerEle);
   cg_solve(Velocity_findrm, Velocity_findrm_size, Velocity_colm, Velocity_colm_size, globalMatrix, globalVector, numNodes, solutionVector);
   expand_data<<<gridXDim,blockXDim>>>(VelocityCoeff, solutionVector, eleNodes, numEle, state->getValsPerNode("Velocity"), nodesPerEle);
-  state->returnFieldToHost("Velocity");
 }
 
 

--- a/tests/expected/cuda/identity/FluidTracer.cu
+++ b/tests/expected/cuda/identity/FluidTracer.cu
@@ -195,7 +195,6 @@ extern "C" void run_model_(double* dt_pointer)
   vector_addto<<<gridXDim,blockXDim>>>(globalVector, eleNodes, localVector, numEle, nodesPerEle);
   cg_solve(Tracer_findrm, Tracer_findrm_size, Tracer_colm, Tracer_colm_size, globalMatrix, globalVector, numNodes, solutionVector);
   expand_data<<<gridXDim,blockXDim>>>(TracerCoeff, solutionVector, eleNodes, numEle, state->getValsPerNode("Tracer"), nodesPerEle);
-  state->returnFieldToHost("Tracer");
 }
 
 

--- a/tests/expected/cuda/identity/FluidTracer.cu
+++ b/tests/expected/cuda/identity/FluidTracer.cu
@@ -197,5 +197,10 @@ extern "C" void run_model_(double* dt_pointer)
   expand_data<<<gridXDim,blockXDim>>>(TracerCoeff, solutionVector, eleNodes, numEle, state->getValsPerNode("Tracer"), nodesPerEle);
 }
 
+extern "C" void return_fields_()
+{
+  state->returnFieldToHost("Tracer");
+}
+
 
 

--- a/tests/expected/cuda/laplacian/model.cu
+++ b/tests/expected/cuda/laplacian/model.cu
@@ -208,7 +208,6 @@ extern "C" void run_model_(double* dt_pointer)
   vector_addto<<<gridXDim,blockXDim>>>(globalVector, eleNodes, localVector, numEle, nodesPerEle);
   cg_solve(Tracer_findrm, Tracer_findrm_size, Tracer_colm, Tracer_colm_size, globalMatrix, globalVector, numNodes, solutionVector);
   expand_data<<<gridXDim,blockXDim>>>(TracerCoeff, solutionVector, eleNodes, numEle, state->getValsPerNode("Tracer"), nodesPerEle);
-  state->returnFieldToHost("Tracer");
 }
 
 

--- a/tests/expected/cuda/laplacian/model.cu
+++ b/tests/expected/cuda/laplacian/model.cu
@@ -210,5 +210,10 @@ extern "C" void run_model_(double* dt_pointer)
   expand_data<<<gridXDim,blockXDim>>>(TracerCoeff, solutionVector, eleNodes, numEle, state->getValsPerNode("Tracer"), nodesPerEle);
 }
 
+extern "C" void return_fields_()
+{
+  state->returnFieldToHost("Tracer");
+}
+
 
 

--- a/tests/expected/cuda/noop/FluidTracer.cu
+++ b/tests/expected/cuda/noop/FluidTracer.cu
@@ -40,5 +40,10 @@ extern "C" void run_model_(double* dt_pointer)
   int gridXDim = 128;
 }
 
+extern "C" void return_fields_()
+{
+
+}
+
 
 

--- a/tests/expected/cuda/simple-advection-diffusion/FluidTracer.cu
+++ b/tests/expected/cuda/simple-advection-diffusion/FluidTracer.cu
@@ -488,5 +488,10 @@ extern "C" void run_model_(double* dt_pointer)
   expand_data<<<gridXDim,blockXDim>>>(TracerCoeff, solutionVector, eleNodes, numEle, state->getValsPerNode("Tracer"), nodesPerEle);
 }
 
+extern "C" void return_fields_()
+{
+  state->returnFieldToHost("Tracer");
+}
+
 
 

--- a/tests/expected/cuda/simple-advection-diffusion/FluidTracer.cu
+++ b/tests/expected/cuda/simple-advection-diffusion/FluidTracer.cu
@@ -486,7 +486,6 @@ extern "C" void run_model_(double* dt_pointer)
   vector_addto<<<gridXDim,blockXDim>>>(globalVector, eleNodes, localVector, numEle, nodesPerEle);
   cg_solve(Tracer_findrm, Tracer_findrm_size, Tracer_colm, Tracer_colm_size, globalMatrix, globalVector, numNodes, solutionVector);
   expand_data<<<gridXDim,blockXDim>>>(TracerCoeff, solutionVector, eleNodes, numEle, state->getValsPerNode("Tracer"), nodesPerEle);
-  state->returnFieldToHost("Tracer");
 }
 
 

--- a/tests/expected/cuda/swapped-advection/model.cu
+++ b/tests/expected/cuda/swapped-advection/model.cu
@@ -220,5 +220,10 @@ extern "C" void run_model_(double* dt_pointer)
   expand_data<<<gridXDim,blockXDim>>>(TracerCoeff, solutionVector, eleNodes, numEle, state->getValsPerNode("Tracer"), nodesPerEle);
 }
 
+extern "C" void return_fields_()
+{
+  state->returnFieldToHost("Tracer");
+}
+
 
 

--- a/tests/expected/cuda/swapped-advection/model.cu
+++ b/tests/expected/cuda/swapped-advection/model.cu
@@ -218,7 +218,6 @@ extern "C" void run_model_(double* dt_pointer)
   vector_addto<<<gridXDim,blockXDim>>>(globalVector, eleNodes, localVector, numEle, nodesPerEle);
   cg_solve(Tracer_findrm, Tracer_findrm_size, Tracer_colm, Tracer_colm_size, globalMatrix, globalVector, numNodes, solutionVector);
   expand_data<<<gridXDim,blockXDim>>>(TracerCoeff, solutionVector, eleNodes, numEle, state->getValsPerNode("Tracer"), nodesPerEle);
-  state->returnFieldToHost("Tracer");
 }
 
 


### PR DESCRIPTION
Presently we transfer the fields from the GPU back to the host at the end of every timestep. This is inefficent. Instead, these changes only transfer the fields back to the host when a call to output_state occurs. 

A summary of the changes are:
- The run_model_ function in generated code no longer incorporates calls to returnFieldToHost
- The generated code contains a new function, return_fields, that has all the returnFieldToHost calls
- In the main UFL program, output_state first calls return_fields, to update the host-side fields with the correct data to write to disk.

These changes have passed the tests on the fluidity-dev queue on the buildbot.
