### PR TITLE
Generate kernels that conform to the OP2 iteration space specification

### DIFF
--- a/mcfc/codegeneration.py
+++ b/mcfc/codegeneration.py
@@ -595,6 +595,8 @@ def getScopeFromNest(nest, depth):
     # Descend through the bodies until we reach the correct one
     for i in range(1,depth):
         loop = body.find(lambda x: isinstance(x, ForLoop))
+        if loop is None: 
+            raise RuntimeError("Loop nest depth exceeded: %d > %d" % (depth, i))
         body = loop.body()
     return body
 

--- a/mcfc/codegeneration.py
+++ b/mcfc/codegeneration.py
@@ -534,6 +534,9 @@ class Pointer(Type):
     def unparse_internal(self):
         return '%s*' % (self._base.unparse())
 
+    def unparse_post(self):
+        return self._base.unparse_post()
+
 class Array(Type):
 
     def __init__(self, base, extents):

--- a/mcfc/codegeneration.py
+++ b/mcfc/codegeneration.py
@@ -276,13 +276,17 @@ class CudaKernelCall(FunctionCall):
 class Scope(BackendASTNode):
 
     def __init__(self, statements=None):
-        self._statements = as_list(statements)
+        s = as_list(statements)
+        s = filter(lambda x: not isinstance(x, NullExpression), s)
+        self._statements = s
 
     def append(self, statement):
-        self._statements.append(statement)
+        if not isinstance(statement, NullExpression):
+            self._statements.append(statement)
 
     def prepend(self, statement):
-        self._statements.insert(0, statement)
+        if not isinstance(statement, NullExpression):
+            self._statements.insert(0, statement)
 
     def find(self, matches):
         for s in self._statements:

--- a/mcfc/cudaexpression.py
+++ b/mcfc/cudaexpression.py
@@ -86,7 +86,7 @@ class CudaQuadratureExpressionBuilder(QuadratureExpressionBuilder):
         indices = [ ElementIndex() ]
         for r in range(tree.rank()):
             indices.append(buildDimIndex(r,tree))
-        indices.append(buildBasisIndex(0, extract_subelement(tree)))
+        indices.append(buildQuadratureBasisIndex(0, extract_subelement(tree)))
         return indices
 
 # vim:sw=4:ts=4:sts=4:et

--- a/mcfc/expression.py
+++ b/mcfc/expression.py
@@ -302,7 +302,7 @@ class QuadratureExpressionBuilder:
         # tensor basis since that is (in UFL) by definition a tensor product of
         # the scalar basis. So we need to extract the sub element.
         # FIXME: This will break for mixed elements
-        indices = [buildBasisIndex(0, extract_subelement(tree)),
+        indices = [buildQuadratureBasisIndex(0, extract_subelement(tree)),
                    buildGaussIndex()]
         return indices
 

--- a/mcfc/form.py
+++ b/mcfc/form.py
@@ -62,14 +62,8 @@ class FormBackend(object):
         loopNest, tensorBody, gaussBody = self.buildExpressionLoopNest(form)
         statements = [loopNest]
 
-        # Initialise the local tensor values to 0
-        initialiser = self.buildLocalTensorInitialiser(form)
-        #loopBody = getScopeFromNest(loopNest, rank)
-        tensorBody.prepend(initialiser)
-
         # Insert the expressions into the loop nest
         partitions = findPartitions(integrand)
-        #loopBody = getScopeFromNest(loopNest, rank + 1)
         loopBody = gaussBody
         for (tree, indices) in partitions:
             expression, listexpressions = self.buildExpression(form, tree)
@@ -143,7 +137,6 @@ class FormBackend(object):
 
         # Build a loop for the quadrature
         gaussLoop = buildIndexForLoop(buildGaussIndex(self.numGaussPoints))
-        #outerLoop = gaussLoop
         
         # Loops over the indices of the local tensor
         outerLoop, tensorLoop = self.buildLocalTensorLoops(form, gaussLoop)
@@ -163,6 +156,10 @@ class FormBackend(object):
             loop.append(basisLoop)
             loop = basisLoop
 
+        # Initialise the local tensor values to 0
+        initialiser = self.buildLocalTensorInitialiser(form)
+        loop.body().prepend(initialiser)
+        
         # Put the gauss loop inside the local tensor loop nest
         loop.append(gaussLoop)
 

--- a/mcfc/form.py
+++ b/mcfc/form.py
@@ -59,7 +59,7 @@ class FormBackend(object):
         declarations = self._buildBasisTensors(form_data)
 
         # Build the loop nest
-        loopNest, tensorBody, gaussBody = self.buildExpressionLoopNest(form)
+        loopNest, gaussBody = self.buildExpressionLoopNest(form)
         statements = [loopNest]
 
         # Insert the expressions into the loop nest
@@ -139,11 +139,11 @@ class FormBackend(object):
         gaussLoop = buildIndexForLoop(buildGaussIndex(self.numGaussPoints))
         
         # Loops over the indices of the local tensor
-        outerLoop, tensorLoop = self.buildLocalTensorLoops(form, gaussLoop)
+        outerLoop = self.buildLocalTensorLoops(form, gaussLoop)
         
         # Hand back the outer loop, so it can be inserted into some
         # scope.
-        return outerLoop, tensorLoop.body(), gaussLoop.body()
+        return outerLoop, gaussLoop.body()
 
     def buildLocalTensorLoops(self, form, gaussLoop):
         # Build the loop over the first rank, which always exists
@@ -163,7 +163,7 @@ class FormBackend(object):
         # Put the gauss loop inside the local tensor loop nest
         loop.append(gaussLoop)
 
-        return outerLoop, loop
+        return outerLoop
 
     def buildCoefficientLoopNest(self, coeff, rank, loop):
         "Build loop nest evaluating a coefficient at a given quadrature point."

--- a/mcfc/form.py
+++ b/mcfc/form.py
@@ -178,7 +178,7 @@ class FormBackend(object):
         loop.append(self.buildCoeffQuadratureInitialiser(coeff))
 
         # One loop over the basis functions of the scalar element
-        basisLoop = buildIndexForLoop(buildBasisIndex(0, extract_subelement(coeff)))
+        basisLoop = buildIndexForLoop(buildQuadratureBasisIndex(0, extract_subelement(coeff)))
         loop.append(basisLoop)
 
         # Add the expression to compute the value inside the basis loop

--- a/mcfc/formutils.py
+++ b/mcfc/formutils.py
@@ -307,6 +307,11 @@ class BasisIndex(CodeIndex):
     def name(self):
         return "i_r_%d" % (self._count)
 
+class QuadratureBasisIndex(BasisIndex):
+
+    def name(self):
+        return "q_r_%d" % (self._count)
+
 class GaussIndex(CodeIndex):
 
     def name(self):
@@ -341,6 +346,10 @@ def extract_subelement(expr):
 def buildBasisIndex(count, e):
     "Build index for a loop over basis function values."
     return BasisIndex(numBasisFunctions(e), count)
+
+def buildQuadratureBasisIndex(count, e):
+    "Build index for a loop over basis function values in the quadrature loop."
+    return QuadratureBasisIndex(numBasisFunctions(e), count)
 
 def buildDimIndex(count, e):
     "Build index for a loop over spatial dimensions."

--- a/mcfc/op2expression.py
+++ b/mcfc/op2expression.py
@@ -57,9 +57,9 @@ class Op2QuadratureExpressionBuilder(QuadratureExpressionBuilder):
         # indexed by separate indices for the scalar basis and the spatial
         # dimension(s) (same for tensor-valued coefficients). Hence we need to
         # extract the scalar element to build the appropriate basis index.
-        indices = [buildBasisIndex(0, extract_subelement(tree))]
+        indices = [buildQuadratureBasisIndex(0, extract_subelement(tree))]
         for r in range(tree.rank()):
             indices.append(buildDimIndex(r,tree))
         return indices
-
+    
 # vim:sw=4:ts=4:sts=4:et

--- a/mcfc/op2expression.py
+++ b/mcfc/op2expression.py
@@ -40,9 +40,12 @@ class Op2ExpressionBuilder(ExpressionBuilder):
     def subscript_LocalTensor(self, form):
         # For matrices the local tensor variable is a pointer to a single entry.
         if form.form_data().rank == 2:
-            return []
+            i = []
         else:
-            return super(Op2ExpressionBuilder,self).subscript_LocalTensor(form)
+            i = super(Op2ExpressionBuilder,self).subscript_LocalTensor(form)
+
+        i.append(buildConstDimIndex(0))
+        return i
 
 class Op2QuadratureExpressionBuilder(QuadratureExpressionBuilder):
 

--- a/mcfc/op2expression.py
+++ b/mcfc/op2expression.py
@@ -37,6 +37,13 @@ class Op2ExpressionBuilder(ExpressionBuilder):
     def buildSubscript(self, variable, indices):
         return buildSubscript(variable, indices)
 
+    def subscript_LocalTensor(self, form):
+        # For matrices the local tensor variable is a pointer to a single entry.
+        if form.form_data().rank == 2:
+            return []
+        else:
+            return super(Op2ExpressionBuilder,self).subscript_LocalTensor(form)
+
 class Op2QuadratureExpressionBuilder(QuadratureExpressionBuilder):
 
     def buildSubscript(self, variable, indices):

--- a/mcfc/op2form.py
+++ b/mcfc/op2form.py
@@ -36,13 +36,24 @@ class Op2FormBackend(FormBackend):
         # Do however use the Jacobian coefficent when building the name, since
         # the coordinate coefficient doesn't get renumbered!
         name = buildCoefficientName(coeff)
-        return buildArrayParameter(name, indices)
+        return buildPtrArrParameter(name, indices)
 
     def _buildLocalTensorParameter(self, form):
-        return buildArrayParameter(localTensor.name(), \
-                self._expressionBuilder.subscript_LocalTensor(form))
+        n = localTensor.name()
+        # OP2 needs a * for a local matrix or a ** for a local vector.
+        # (Yes, really).
+        if form.form_data().rank == 2:
+            return buildPtrParameter(n)
+        else: 
+            return buildPtrPtrParameter(n)
 
-def buildArrayParameter(name, indices):
-    return Variable(name, Array(Real(), [i.extent() for i in indices]))
+def buildPtrParameter(name):
+    return Variable(name, Pointer(Real()))
+
+def buildPtrPtrParameter(name):
+    return Variable(name, Pointer(Pointer(Real())))
+
+def buildPtrArrParameter(name, indices):
+    return Variable(name, Pointer(Array(Real(), [i.extent() for i in indices[1:]])))
 
 # vim:sw=4:ts=4:sts=4:et

--- a/mcfc/op2form.py
+++ b/mcfc/op2form.py
@@ -53,6 +53,16 @@ class Op2FormBackend(FormBackend):
             return NullExpression();
         else:
             return super(Op2FormBackend, self).buildLocalTensorInitialiser(form)
+    
+    def buildLocalTensorLoops(self, form, gaussLoop):
+        if form.form_data().rank == 2:
+            # FIXME: (before merge) returns a dummy scope for the local tensor
+            # initialiser to go in to. ideally we should be more smart and not
+            # be attempting to build the LT initialiser at all if it's not
+            # required
+            return gaussLoop, ForLoop(0,0,0)
+        else:
+            return super(Op2FormBackend, self).buildLocalTensorLoops(form, gaussLoop)
 
     def _buildKernelParameters(self, form):
         p = super(Op2FormBackend, self)._buildKernelParameters(form)

--- a/mcfc/op2form.py
+++ b/mcfc/op2form.py
@@ -48,12 +48,10 @@ class Op2FormBackend(FormBackend):
             return buildPtrPtrParameter(n)
 
     def buildLocalTensorLoops(self, form, gaussLoop):
+        # In the matrix case, there are no loops over the indices of the local
+        # tensor.
         if form.form_data().rank == 2:
-            # FIXME: (before merge) returns a dummy scope for the local tensor
-            # initialiser to go in to. ideally we should be more smart and not
-            # be attempting to build the LT initialiser at all if it's not
-            # required
-            return gaussLoop, ForLoop(0,0,0)
+            return gaussLoop
         else:
             return super(Op2FormBackend, self).buildLocalTensorLoops(form, gaussLoop)
 

--- a/mcfc/op2form.py
+++ b/mcfc/op2form.py
@@ -47,6 +47,13 @@ class Op2FormBackend(FormBackend):
         else: 
             return buildPtrPtrParameter(n)
 
+    def buildLocalTensorInitialiser(self, form):
+        # For matrices the local tensor doesn't need to be initialised.
+        if form.form_data().rank == 2:
+            return NullExpression();
+        else:
+            return super(Op2FormBackend, self).buildLocalTensorInitialiser(form)
+
     def _buildKernelParameters(self, form):
         p = super(Op2FormBackend, self)._buildKernelParameters(form)
         # For a local matrix, we need parameters for the op2 iteration space

--- a/mcfc/op2form.py
+++ b/mcfc/op2form.py
@@ -59,7 +59,8 @@ class Op2FormBackend(FormBackend):
         p = super(Op2FormBackend, self)._buildKernelParameters(form)
         # For a local matrix, we need parameters for the op2 iteration space
         if form.form_data().rank == 2:
-            p.extend([Variable("i", Integer()), Variable("j", Integer())])
+            i, j = BasisIndex(0, 0), BasisIndex(0, 1)
+            p.extend([Variable(i.name(), Integer()), Variable(j.name(), Integer())])
         return p
 
 def buildPtrParameter(name):

--- a/mcfc/op2form.py
+++ b/mcfc/op2form.py
@@ -47,13 +47,6 @@ class Op2FormBackend(FormBackend):
         else: 
             return buildPtrPtrParameter(n)
 
-    def buildLocalTensorInitialiser(self, form):
-        # For matrices the local tensor doesn't need to be initialised.
-        if form.form_data().rank == 2:
-            return NullExpression();
-        else:
-            return super(Op2FormBackend, self).buildLocalTensorInitialiser(form)
-    
     def buildLocalTensorLoops(self, form, gaussLoop):
         if form.form_data().rank == 2:
             # FIXME: (before merge) returns a dummy scope for the local tensor

--- a/mcfc/op2form.py
+++ b/mcfc/op2form.py
@@ -47,6 +47,13 @@ class Op2FormBackend(FormBackend):
         else: 
             return buildPtrPtrParameter(n)
 
+    def _buildKernelParameters(self, form):
+        p = super(Op2FormBackend, self)._buildKernelParameters(form)
+        # For a local matrix, we need parameters for the op2 iteration space
+        if form.form_data().rank == 2:
+            p.extend([Variable("i", Integer()), Variable("j", Integer())])
+        return p
+
 def buildPtrParameter(name):
     return Variable(name, Pointer(Real()))
 

--- a/tests/expected/cuda/diffusion-1/model.cu
+++ b/tests/expected/cuda/diffusion-1/model.cu
@@ -56,9 +56,9 @@ __global__ void A(int n_ele, double* localTensor, double dt, double* c0, double*
         for(int i_d_1 = 0; i_d_1 < 2; i_d_1++)
         {
           c_q1[i_g][i_d_0][i_d_1] = 0.0;
-          for(int i_r_0 = 0; i_r_0 < 3; i_r_0++)
+          for(int q_r_0 = 0; q_r_0 < 3; q_r_0++)
           {
-            c_q1[i_g][i_d_0][i_d_1] += c1[i_ele + n_ele * (i_d_0 + 2 * (i_d_1 + 2 * i_r_0))] * CG1[i_r_0][i_g];
+            c_q1[i_g][i_d_0][i_d_1] += c1[i_ele + n_ele * (i_d_0 + 2 * (i_d_1 + 2 * q_r_0))] * CG1[q_r_0][i_g];
           };
         };
       };
@@ -67,9 +67,9 @@ __global__ void A(int n_ele, double* localTensor, double dt, double* c0, double*
         for(int i_d_1 = 0; i_d_1 < 2; i_d_1++)
         {
           c_q0[i_g][i_d_0][i_d_1] = 0.0;
-          for(int i_r_0 = 0; i_r_0 < 3; i_r_0++)
+          for(int q_r_0 = 0; q_r_0 < 3; q_r_0++)
           {
-            c_q0[i_g][i_d_0][i_d_1] += c0[i_ele + n_ele * (i_d_0 + 2 * i_r_0)] * d_CG1[i_r_0][i_g][i_d_1];
+            c_q0[i_g][i_d_0][i_d_1] += c0[i_ele + n_ele * (i_d_0 + 2 * q_r_0)] * d_CG1[q_r_0][i_g][i_d_1];
           };
         };
       };
@@ -149,9 +149,9 @@ __global__ void d(int n_ele, double* localTensor, double dt, double* c0, double*
         for(int i_d_1 = 0; i_d_1 < 2; i_d_1++)
         {
           c_q1[i_g][i_d_0][i_d_1] = 0.0;
-          for(int i_r_0 = 0; i_r_0 < 3; i_r_0++)
+          for(int q_r_0 = 0; q_r_0 < 3; q_r_0++)
           {
-            c_q1[i_g][i_d_0][i_d_1] += c1[i_ele + n_ele * (i_d_0 + 2 * (i_d_1 + 2 * i_r_0))] * CG1[i_r_0][i_g];
+            c_q1[i_g][i_d_0][i_d_1] += c1[i_ele + n_ele * (i_d_0 + 2 * (i_d_1 + 2 * q_r_0))] * CG1[q_r_0][i_g];
           };
         };
       };
@@ -160,9 +160,9 @@ __global__ void d(int n_ele, double* localTensor, double dt, double* c0, double*
         for(int i_d_1 = 0; i_d_1 < 2; i_d_1++)
         {
           c_q0[i_g][i_d_0][i_d_1] = 0.0;
-          for(int i_r_0 = 0; i_r_0 < 3; i_r_0++)
+          for(int q_r_0 = 0; q_r_0 < 3; q_r_0++)
           {
-            c_q0[i_g][i_d_0][i_d_1] += c0[i_ele + n_ele * (i_d_0 + 2 * i_r_0)] * d_CG1[i_r_0][i_g][i_d_1];
+            c_q0[i_g][i_d_0][i_d_1] += c0[i_ele + n_ele * (i_d_0 + 2 * q_r_0)] * d_CG1[q_r_0][i_g][i_d_1];
           };
         };
       };
@@ -239,9 +239,9 @@ __global__ void M(int n_ele, double* localTensor, double dt, double* c0)
         for(int i_d_1 = 0; i_d_1 < 2; i_d_1++)
         {
           c_q0[i_g][i_d_0][i_d_1] = 0.0;
-          for(int i_r_0 = 0; i_r_0 < 3; i_r_0++)
+          for(int q_r_0 = 0; q_r_0 < 3; q_r_0++)
           {
-            c_q0[i_g][i_d_0][i_d_1] += c0[i_ele + n_ele * (i_d_0 + 2 * i_r_0)] * d_CG1[i_r_0][i_g][i_d_1];
+            c_q0[i_g][i_d_0][i_d_1] += c0[i_ele + n_ele * (i_d_0 + 2 * q_r_0)] * d_CG1[q_r_0][i_g][i_d_1];
           };
         };
       };
@@ -305,9 +305,9 @@ __global__ void rhs(int n_ele, double* localTensor, double dt, double* c0, doubl
         for(int i_d_1 = 0; i_d_1 < 2; i_d_1++)
         {
           c_q2[i_g][i_d_0][i_d_1] = 0.0;
-          for(int i_r_0 = 0; i_r_0 < 3; i_r_0++)
+          for(int q_r_0 = 0; q_r_0 < 3; q_r_0++)
           {
-            c_q2[i_g][i_d_0][i_d_1] += c2[i_ele + n_ele * (i_d_0 + 2 * (i_d_1 + 2 * i_r_0))] * CG1[i_r_0][i_g];
+            c_q2[i_g][i_d_0][i_d_1] += c2[i_ele + n_ele * (i_d_0 + 2 * (i_d_1 + 2 * q_r_0))] * CG1[q_r_0][i_g];
           };
         };
       };
@@ -316,23 +316,23 @@ __global__ void rhs(int n_ele, double* localTensor, double dt, double* c0, doubl
         for(int i_d_1 = 0; i_d_1 < 2; i_d_1++)
         {
           c_q0[i_g][i_d_0][i_d_1] = 0.0;
-          for(int i_r_0 = 0; i_r_0 < 3; i_r_0++)
+          for(int q_r_0 = 0; q_r_0 < 3; q_r_0++)
           {
-            c_q0[i_g][i_d_0][i_d_1] += c0[i_ele + n_ele * (i_d_0 + 2 * i_r_0)] * d_CG1[i_r_0][i_g][i_d_1];
+            c_q0[i_g][i_d_0][i_d_1] += c0[i_ele + n_ele * (i_d_0 + 2 * q_r_0)] * d_CG1[q_r_0][i_g][i_d_1];
           };
         };
       };
       c_q1[i_g] = 0.0;
-      for(int i_r_0 = 0; i_r_0 < 3; i_r_0++)
+      for(int q_r_0 = 0; q_r_0 < 3; q_r_0++)
       {
-        c_q1[i_g] += c1[i_ele + n_ele * i_r_0] * CG1[i_r_0][i_g];
+        c_q1[i_g] += c1[i_ele + n_ele * q_r_0] * CG1[q_r_0][i_g];
       };
       for(int i_d_0 = 0; i_d_0 < 2; i_d_0++)
       {
         d_c_q1[i_g][i_d_0] = 0.0;
-        for(int i_r_0 = 0; i_r_0 < 3; i_r_0++)
+        for(int q_r_0 = 0; q_r_0 < 3; q_r_0++)
         {
-          d_c_q1[i_g][i_d_0] += c1[i_ele + n_ele * i_r_0] * d_CG1[i_r_0][i_g][i_d_0];
+          d_c_q1[i_g][i_d_0] += c1[i_ele + n_ele * q_r_0] * d_CG1[q_r_0][i_g][i_d_0];
         };
       };
     };

--- a/tests/expected/cuda/diffusion-2/model.cu
+++ b/tests/expected/cuda/diffusion-2/model.cu
@@ -56,9 +56,9 @@ __global__ void A(int n_ele, double* localTensor, double dt, double* c0, double*
         for(int i_d_1 = 0; i_d_1 < 2; i_d_1++)
         {
           c_q1[i_g][i_d_0][i_d_1] = 0.0;
-          for(int i_r_0 = 0; i_r_0 < 3; i_r_0++)
+          for(int q_r_0 = 0; q_r_0 < 3; q_r_0++)
           {
-            c_q1[i_g][i_d_0][i_d_1] += c1[i_ele + n_ele * (i_d_0 + 2 * (i_d_1 + 2 * i_r_0))] * CG1[i_r_0][i_g];
+            c_q1[i_g][i_d_0][i_d_1] += c1[i_ele + n_ele * (i_d_0 + 2 * (i_d_1 + 2 * q_r_0))] * CG1[q_r_0][i_g];
           };
         };
       };
@@ -67,9 +67,9 @@ __global__ void A(int n_ele, double* localTensor, double dt, double* c0, double*
         for(int i_d_1 = 0; i_d_1 < 2; i_d_1++)
         {
           c_q0[i_g][i_d_0][i_d_1] = 0.0;
-          for(int i_r_0 = 0; i_r_0 < 3; i_r_0++)
+          for(int q_r_0 = 0; q_r_0 < 3; q_r_0++)
           {
-            c_q0[i_g][i_d_0][i_d_1] += c0[i_ele + n_ele * (i_d_0 + 2 * i_r_0)] * d_CG1[i_r_0][i_g][i_d_1];
+            c_q0[i_g][i_d_0][i_d_1] += c0[i_ele + n_ele * (i_d_0 + 2 * q_r_0)] * d_CG1[q_r_0][i_g][i_d_1];
           };
         };
       };
@@ -149,9 +149,9 @@ __global__ void d(int n_ele, double* localTensor, double dt, double* c0, double*
         for(int i_d_1 = 0; i_d_1 < 2; i_d_1++)
         {
           c_q1[i_g][i_d_0][i_d_1] = 0.0;
-          for(int i_r_0 = 0; i_r_0 < 3; i_r_0++)
+          for(int q_r_0 = 0; q_r_0 < 3; q_r_0++)
           {
-            c_q1[i_g][i_d_0][i_d_1] += c1[i_ele + n_ele * (i_d_0 + 2 * (i_d_1 + 2 * i_r_0))] * CG1[i_r_0][i_g];
+            c_q1[i_g][i_d_0][i_d_1] += c1[i_ele + n_ele * (i_d_0 + 2 * (i_d_1 + 2 * q_r_0))] * CG1[q_r_0][i_g];
           };
         };
       };
@@ -160,9 +160,9 @@ __global__ void d(int n_ele, double* localTensor, double dt, double* c0, double*
         for(int i_d_1 = 0; i_d_1 < 2; i_d_1++)
         {
           c_q0[i_g][i_d_0][i_d_1] = 0.0;
-          for(int i_r_0 = 0; i_r_0 < 3; i_r_0++)
+          for(int q_r_0 = 0; q_r_0 < 3; q_r_0++)
           {
-            c_q0[i_g][i_d_0][i_d_1] += c0[i_ele + n_ele * (i_d_0 + 2 * i_r_0)] * d_CG1[i_r_0][i_g][i_d_1];
+            c_q0[i_g][i_d_0][i_d_1] += c0[i_ele + n_ele * (i_d_0 + 2 * q_r_0)] * d_CG1[q_r_0][i_g][i_d_1];
           };
         };
       };
@@ -239,9 +239,9 @@ __global__ void M(int n_ele, double* localTensor, double dt, double* c0)
         for(int i_d_1 = 0; i_d_1 < 2; i_d_1++)
         {
           c_q0[i_g][i_d_0][i_d_1] = 0.0;
-          for(int i_r_0 = 0; i_r_0 < 3; i_r_0++)
+          for(int q_r_0 = 0; q_r_0 < 3; q_r_0++)
           {
-            c_q0[i_g][i_d_0][i_d_1] += c0[i_ele + n_ele * (i_d_0 + 2 * i_r_0)] * d_CG1[i_r_0][i_g][i_d_1];
+            c_q0[i_g][i_d_0][i_d_1] += c0[i_ele + n_ele * (i_d_0 + 2 * q_r_0)] * d_CG1[q_r_0][i_g][i_d_1];
           };
         };
       };
@@ -305,9 +305,9 @@ __global__ void rhs(int n_ele, double* localTensor, double dt, double* c0, doubl
         for(int i_d_1 = 0; i_d_1 < 2; i_d_1++)
         {
           c_q2[i_g][i_d_0][i_d_1] = 0.0;
-          for(int i_r_0 = 0; i_r_0 < 3; i_r_0++)
+          for(int q_r_0 = 0; q_r_0 < 3; q_r_0++)
           {
-            c_q2[i_g][i_d_0][i_d_1] += c2[i_ele + n_ele * (i_d_0 + 2 * (i_d_1 + 2 * i_r_0))] * CG1[i_r_0][i_g];
+            c_q2[i_g][i_d_0][i_d_1] += c2[i_ele + n_ele * (i_d_0 + 2 * (i_d_1 + 2 * q_r_0))] * CG1[q_r_0][i_g];
           };
         };
       };
@@ -316,23 +316,23 @@ __global__ void rhs(int n_ele, double* localTensor, double dt, double* c0, doubl
         for(int i_d_1 = 0; i_d_1 < 2; i_d_1++)
         {
           c_q0[i_g][i_d_0][i_d_1] = 0.0;
-          for(int i_r_0 = 0; i_r_0 < 3; i_r_0++)
+          for(int q_r_0 = 0; q_r_0 < 3; q_r_0++)
           {
-            c_q0[i_g][i_d_0][i_d_1] += c0[i_ele + n_ele * (i_d_0 + 2 * i_r_0)] * d_CG1[i_r_0][i_g][i_d_1];
+            c_q0[i_g][i_d_0][i_d_1] += c0[i_ele + n_ele * (i_d_0 + 2 * q_r_0)] * d_CG1[q_r_0][i_g][i_d_1];
           };
         };
       };
       c_q1[i_g] = 0.0;
-      for(int i_r_0 = 0; i_r_0 < 3; i_r_0++)
+      for(int q_r_0 = 0; q_r_0 < 3; q_r_0++)
       {
-        c_q1[i_g] += c1[i_ele + n_ele * i_r_0] * CG1[i_r_0][i_g];
+        c_q1[i_g] += c1[i_ele + n_ele * q_r_0] * CG1[q_r_0][i_g];
       };
       for(int i_d_0 = 0; i_d_0 < 2; i_d_0++)
       {
         d_c_q1[i_g][i_d_0] = 0.0;
-        for(int i_r_0 = 0; i_r_0 < 3; i_r_0++)
+        for(int q_r_0 = 0; q_r_0 < 3; q_r_0++)
         {
-          d_c_q1[i_g][i_d_0] += c1[i_ele + n_ele * i_r_0] * d_CG1[i_r_0][i_g][i_d_0];
+          d_c_q1[i_g][i_d_0] += c1[i_ele + n_ele * q_r_0] * d_CG1[q_r_0][i_g][i_d_0];
         };
       };
     };

--- a/tests/expected/cuda/diffusion-3/FluidTracer.cu
+++ b/tests/expected/cuda/diffusion-3/FluidTracer.cu
@@ -55,9 +55,9 @@ __global__ void A(int n_ele, double* localTensor, double dt, double* c0)
         for(int i_d_1 = 0; i_d_1 < 2; i_d_1++)
         {
           c_q0[i_g][i_d_0][i_d_1] = 0.0;
-          for(int i_r_0 = 0; i_r_0 < 3; i_r_0++)
+          for(int q_r_0 = 0; q_r_0 < 3; q_r_0++)
           {
-            c_q0[i_g][i_d_0][i_d_1] += c0[i_ele + n_ele * (i_d_0 + 2 * i_r_0)] * d_CG1[i_r_0][i_g][i_d_1];
+            c_q0[i_g][i_d_0][i_d_1] += c0[i_ele + n_ele * (i_d_0 + 2 * q_r_0)] * d_CG1[q_r_0][i_g][i_d_1];
           };
         };
       };
@@ -135,9 +135,9 @@ __global__ void d(int n_ele, double* localTensor, double dt, double* c0)
         for(int i_d_1 = 0; i_d_1 < 2; i_d_1++)
         {
           c_q0[i_g][i_d_0][i_d_1] = 0.0;
-          for(int i_r_0 = 0; i_r_0 < 3; i_r_0++)
+          for(int q_r_0 = 0; q_r_0 < 3; q_r_0++)
           {
-            c_q0[i_g][i_d_0][i_d_1] += c0[i_ele + n_ele * (i_d_0 + 2 * i_r_0)] * d_CG1[i_r_0][i_g][i_d_1];
+            c_q0[i_g][i_d_0][i_d_1] += c0[i_ele + n_ele * (i_d_0 + 2 * q_r_0)] * d_CG1[q_r_0][i_g][i_d_1];
           };
         };
       };
@@ -213,9 +213,9 @@ __global__ void M(int n_ele, double* localTensor, double dt, double* c0)
         for(int i_d_1 = 0; i_d_1 < 2; i_d_1++)
         {
           c_q0[i_g][i_d_0][i_d_1] = 0.0;
-          for(int i_r_0 = 0; i_r_0 < 3; i_r_0++)
+          for(int q_r_0 = 0; q_r_0 < 3; q_r_0++)
           {
-            c_q0[i_g][i_d_0][i_d_1] += c0[i_ele + n_ele * (i_d_0 + 2 * i_r_0)] * d_CG1[i_r_0][i_g][i_d_1];
+            c_q0[i_g][i_d_0][i_d_1] += c0[i_ele + n_ele * (i_d_0 + 2 * q_r_0)] * d_CG1[q_r_0][i_g][i_d_1];
           };
         };
       };
@@ -278,23 +278,23 @@ __global__ void rhs(int n_ele, double* localTensor, double dt, double* c0, doubl
         for(int i_d_1 = 0; i_d_1 < 2; i_d_1++)
         {
           c_q0[i_g][i_d_0][i_d_1] = 0.0;
-          for(int i_r_0 = 0; i_r_0 < 3; i_r_0++)
+          for(int q_r_0 = 0; q_r_0 < 3; q_r_0++)
           {
-            c_q0[i_g][i_d_0][i_d_1] += c0[i_ele + n_ele * (i_d_0 + 2 * i_r_0)] * d_CG1[i_r_0][i_g][i_d_1];
+            c_q0[i_g][i_d_0][i_d_1] += c0[i_ele + n_ele * (i_d_0 + 2 * q_r_0)] * d_CG1[q_r_0][i_g][i_d_1];
           };
         };
       };
       c_q1[i_g] = 0.0;
-      for(int i_r_0 = 0; i_r_0 < 3; i_r_0++)
+      for(int q_r_0 = 0; q_r_0 < 3; q_r_0++)
       {
-        c_q1[i_g] += c1[i_ele + n_ele * i_r_0] * CG1[i_r_0][i_g];
+        c_q1[i_g] += c1[i_ele + n_ele * q_r_0] * CG1[q_r_0][i_g];
       };
       for(int i_d_0 = 0; i_d_0 < 2; i_d_0++)
       {
         d_c_q1[i_g][i_d_0] = 0.0;
-        for(int i_r_0 = 0; i_r_0 < 3; i_r_0++)
+        for(int q_r_0 = 0; q_r_0 < 3; q_r_0++)
         {
-          d_c_q1[i_g][i_d_0] += c1[i_ele + n_ele * i_r_0] * d_CG1[i_r_0][i_g][i_d_0];
+          d_c_q1[i_g][i_d_0] += c1[i_ele + n_ele * q_r_0] * d_CG1[q_r_0][i_g][i_d_0];
         };
       };
     };

--- a/tests/expected/cuda/euler-advection/FluidTracer.cu
+++ b/tests/expected/cuda/euler-advection/FluidTracer.cu
@@ -57,23 +57,23 @@ __global__ void rhs(int n_ele, double* localTensor, double dt, double* c0, doubl
         for(int i_d_1 = 0; i_d_1 < 2; i_d_1++)
         {
           c_q0[i_g][i_d_0][i_d_1] = 0.0;
-          for(int i_r_0 = 0; i_r_0 < 3; i_r_0++)
+          for(int q_r_0 = 0; q_r_0 < 3; q_r_0++)
           {
-            c_q0[i_g][i_d_0][i_d_1] += c0[i_ele + n_ele * (i_d_0 + 2 * i_r_0)] * d_CG1[i_r_0][i_g][i_d_1];
+            c_q0[i_g][i_d_0][i_d_1] += c0[i_ele + n_ele * (i_d_0 + 2 * q_r_0)] * d_CG1[q_r_0][i_g][i_d_1];
           };
         };
       };
       c_q1[i_g] = 0.0;
-      for(int i_r_0 = 0; i_r_0 < 3; i_r_0++)
+      for(int q_r_0 = 0; q_r_0 < 3; q_r_0++)
       {
-        c_q1[i_g] += c1[i_ele + n_ele * i_r_0] * CG1[i_r_0][i_g];
+        c_q1[i_g] += c1[i_ele + n_ele * q_r_0] * CG1[q_r_0][i_g];
       };
       for(int i_d_0 = 0; i_d_0 < 2; i_d_0++)
       {
         c_q2[i_g][i_d_0] = 0.0;
-        for(int i_r_0 = 0; i_r_0 < 3; i_r_0++)
+        for(int q_r_0 = 0; q_r_0 < 3; q_r_0++)
         {
-          c_q2[i_g][i_d_0] += c2[i_ele + n_ele * (i_d_0 + 2 * i_r_0)] * CG1[i_r_0][i_g];
+          c_q2[i_g][i_d_0] += c2[i_ele + n_ele * (i_d_0 + 2 * q_r_0)] * CG1[q_r_0][i_g];
         };
       };
     };
@@ -141,9 +141,9 @@ __global__ void Mass(int n_ele, double* localTensor, double dt, double* c0)
         for(int i_d_1 = 0; i_d_1 < 2; i_d_1++)
         {
           c_q0[i_g][i_d_0][i_d_1] = 0.0;
-          for(int i_r_0 = 0; i_r_0 < 3; i_r_0++)
+          for(int q_r_0 = 0; q_r_0 < 3; q_r_0++)
           {
-            c_q0[i_g][i_d_0][i_d_1] += c0[i_ele + n_ele * (i_d_0 + 2 * i_r_0)] * d_CG1[i_r_0][i_g][i_d_1];
+            c_q0[i_g][i_d_0][i_d_1] += c0[i_ele + n_ele * (i_d_0 + 2 * q_r_0)] * d_CG1[q_r_0][i_g][i_d_1];
           };
         };
       };

--- a/tests/expected/cuda/helmholtz/FluidTracer.cu
+++ b/tests/expected/cuda/helmholtz/FluidTracer.cu
@@ -55,9 +55,9 @@ __global__ void A(int n_ele, double* localTensor, double dt, double* c0)
         for(int i_d_1 = 0; i_d_1 < 2; i_d_1++)
         {
           c_q0[i_g][i_d_0][i_d_1] = 0.0;
-          for(int i_r_0 = 0; i_r_0 < 3; i_r_0++)
+          for(int q_r_0 = 0; q_r_0 < 3; q_r_0++)
           {
-            c_q0[i_g][i_d_0][i_d_1] += c0[i_ele + n_ele * (i_d_0 + 2 * i_r_0)] * d_CG1[i_r_0][i_g][i_d_1];
+            c_q0[i_g][i_d_0][i_d_1] += c0[i_ele + n_ele * (i_d_0 + 2 * q_r_0)] * d_CG1[q_r_0][i_g][i_d_1];
           };
         };
       };
@@ -130,18 +130,18 @@ __global__ void RHS(int n_ele, double* localTensor, double dt, double* c0, doubl
     for(int i_g = 0; i_g < 6; i_g++)
     {
       c_q1[i_g] = 0.0;
-      for(int i_r_0 = 0; i_r_0 < 3; i_r_0++)
+      for(int q_r_0 = 0; q_r_0 < 3; q_r_0++)
       {
-        c_q1[i_g] += c1[i_ele + n_ele * i_r_0] * CG1[i_r_0][i_g];
+        c_q1[i_g] += c1[i_ele + n_ele * q_r_0] * CG1[q_r_0][i_g];
       };
       for(int i_d_0 = 0; i_d_0 < 2; i_d_0++)
       {
         for(int i_d_1 = 0; i_d_1 < 2; i_d_1++)
         {
           c_q0[i_g][i_d_0][i_d_1] = 0.0;
-          for(int i_r_0 = 0; i_r_0 < 3; i_r_0++)
+          for(int q_r_0 = 0; q_r_0 < 3; q_r_0++)
           {
-            c_q0[i_g][i_d_0][i_d_1] += c0[i_ele + n_ele * (i_d_0 + 2 * i_r_0)] * d_CG1[i_r_0][i_g][i_d_1];
+            c_q0[i_g][i_d_0][i_d_1] += c0[i_ele + n_ele * (i_d_0 + 2 * q_r_0)] * d_CG1[q_r_0][i_g][i_d_1];
           };
         };
       };

--- a/tests/expected/cuda/identity-vector/model.cu
+++ b/tests/expected/cuda/identity-vector/model.cu
@@ -80,9 +80,9 @@ __global__ void A(int n_ele, double* localTensor, double dt, double* c0)
         for(int i_d_1 = 0; i_d_1 < 2; i_d_1++)
         {
           c_q0[i_g][i_d_0][i_d_1] = 0.0;
-          for(int i_r_0 = 0; i_r_0 < 3; i_r_0++)
+          for(int q_r_0 = 0; q_r_0 < 3; q_r_0++)
           {
-            c_q0[i_g][i_d_0][i_d_1] += c0[i_ele + n_ele * (i_d_0 + 2 * i_r_0)] * d_CG1[i_r_0][i_g][i_d_1];
+            c_q0[i_g][i_d_0][i_d_1] += c0[i_ele + n_ele * (i_d_0 + 2 * q_r_0)] * d_CG1[q_r_0][i_g][i_d_1];
           };
         };
       };
@@ -172,9 +172,9 @@ __global__ void RHS(int n_ele, double* localTensor, double dt, double* c0, doubl
       for(int i_d_0 = 0; i_d_0 < 2; i_d_0++)
       {
         c_q1[i_g][i_d_0] = 0.0;
-        for(int i_r_0 = 0; i_r_0 < 3; i_r_0++)
+        for(int q_r_0 = 0; q_r_0 < 3; q_r_0++)
         {
-          c_q1[i_g][i_d_0] += c1[i_ele + n_ele * (i_d_0 + 2 * i_r_0)] * CG1[i_r_0][i_g];
+          c_q1[i_g][i_d_0] += c1[i_ele + n_ele * (i_d_0 + 2 * q_r_0)] * CG1[q_r_0][i_g];
         };
       };
       for(int i_d_0 = 0; i_d_0 < 2; i_d_0++)
@@ -182,9 +182,9 @@ __global__ void RHS(int n_ele, double* localTensor, double dt, double* c0, doubl
         for(int i_d_1 = 0; i_d_1 < 2; i_d_1++)
         {
           c_q0[i_g][i_d_0][i_d_1] = 0.0;
-          for(int i_r_0 = 0; i_r_0 < 3; i_r_0++)
+          for(int q_r_0 = 0; q_r_0 < 3; q_r_0++)
           {
-            c_q0[i_g][i_d_0][i_d_1] += c0[i_ele + n_ele * (i_d_0 + 2 * i_r_0)] * d_CG1[i_r_0][i_g][i_d_1];
+            c_q0[i_g][i_d_0][i_d_1] += c0[i_ele + n_ele * (i_d_0 + 2 * q_r_0)] * d_CG1[q_r_0][i_g][i_d_1];
           };
         };
       };

--- a/tests/expected/cuda/identity/FluidTracer.cu
+++ b/tests/expected/cuda/identity/FluidTracer.cu
@@ -55,9 +55,9 @@ __global__ void a(int n_ele, double* localTensor, double dt, double* c0)
         for(int i_d_1 = 0; i_d_1 < 2; i_d_1++)
         {
           c_q0[i_g][i_d_0][i_d_1] = 0.0;
-          for(int i_r_0 = 0; i_r_0 < 3; i_r_0++)
+          for(int q_r_0 = 0; q_r_0 < 3; q_r_0++)
           {
-            c_q0[i_g][i_d_0][i_d_1] += c0[i_ele + n_ele * (i_d_0 + 2 * i_r_0)] * d_CG1[i_r_0][i_g][i_d_1];
+            c_q0[i_g][i_d_0][i_d_1] += c0[i_ele + n_ele * (i_d_0 + 2 * q_r_0)] * d_CG1[q_r_0][i_g][i_d_1];
           };
         };
       };
@@ -115,18 +115,18 @@ __global__ void L(int n_ele, double* localTensor, double dt, double* c0, double*
     for(int i_g = 0; i_g < 6; i_g++)
     {
       c_q1[i_g] = 0.0;
-      for(int i_r_0 = 0; i_r_0 < 3; i_r_0++)
+      for(int q_r_0 = 0; q_r_0 < 3; q_r_0++)
       {
-        c_q1[i_g] += c1[i_ele + n_ele * i_r_0] * CG1[i_r_0][i_g];
+        c_q1[i_g] += c1[i_ele + n_ele * q_r_0] * CG1[q_r_0][i_g];
       };
       for(int i_d_0 = 0; i_d_0 < 2; i_d_0++)
       {
         for(int i_d_1 = 0; i_d_1 < 2; i_d_1++)
         {
           c_q0[i_g][i_d_0][i_d_1] = 0.0;
-          for(int i_r_0 = 0; i_r_0 < 3; i_r_0++)
+          for(int q_r_0 = 0; q_r_0 < 3; q_r_0++)
           {
-            c_q0[i_g][i_d_0][i_d_1] += c0[i_ele + n_ele * (i_d_0 + 2 * i_r_0)] * d_CG1[i_r_0][i_g][i_d_1];
+            c_q0[i_g][i_d_0][i_d_1] += c0[i_ele + n_ele * (i_d_0 + 2 * q_r_0)] * d_CG1[q_r_0][i_g][i_d_1];
           };
         };
       };

--- a/tests/expected/cuda/laplacian/model.cu
+++ b/tests/expected/cuda/laplacian/model.cu
@@ -55,9 +55,9 @@ __global__ void A(int n_ele, double* localTensor, double dt, double* c0)
         for(int i_d_1 = 0; i_d_1 < 2; i_d_1++)
         {
           c_q0[i_g][i_d_0][i_d_1] = 0.0;
-          for(int i_r_0 = 0; i_r_0 < 3; i_r_0++)
+          for(int q_r_0 = 0; q_r_0 < 3; q_r_0++)
           {
-            c_q0[i_g][i_d_0][i_d_1] += c0[i_ele + n_ele * (i_d_0 + 2 * i_r_0)] * d_CG1[i_r_0][i_g][i_d_1];
+            c_q0[i_g][i_d_0][i_d_1] += c0[i_ele + n_ele * (i_d_0 + 2 * q_r_0)] * d_CG1[q_r_0][i_g][i_d_1];
           };
         };
       };
@@ -128,18 +128,18 @@ __global__ void RHS(int n_ele, double* localTensor, double dt, double* c0, doubl
     for(int i_g = 0; i_g < 6; i_g++)
     {
       c_q1[i_g] = 0.0;
-      for(int i_r_0 = 0; i_r_0 < 3; i_r_0++)
+      for(int q_r_0 = 0; q_r_0 < 3; q_r_0++)
       {
-        c_q1[i_g] += c1[i_ele + n_ele * i_r_0] * CG1[i_r_0][i_g];
+        c_q1[i_g] += c1[i_ele + n_ele * q_r_0] * CG1[q_r_0][i_g];
       };
       for(int i_d_0 = 0; i_d_0 < 2; i_d_0++)
       {
         for(int i_d_1 = 0; i_d_1 < 2; i_d_1++)
         {
           c_q0[i_g][i_d_0][i_d_1] = 0.0;
-          for(int i_r_0 = 0; i_r_0 < 3; i_r_0++)
+          for(int q_r_0 = 0; q_r_0 < 3; q_r_0++)
           {
-            c_q0[i_g][i_d_0][i_d_1] += c0[i_ele + n_ele * (i_d_0 + 2 * i_r_0)] * d_CG1[i_r_0][i_g][i_d_1];
+            c_q0[i_g][i_d_0][i_d_1] += c0[i_ele + n_ele * (i_d_0 + 2 * q_r_0)] * d_CG1[q_r_0][i_g][i_d_1];
           };
         };
       };

--- a/tests/expected/cuda/simple-advection-diffusion/FluidTracer.cu
+++ b/tests/expected/cuda/simple-advection-diffusion/FluidTracer.cu
@@ -59,9 +59,9 @@ __global__ void A(int n_ele, double* localTensor, double dt, double* c0)
         for(int i_d_1 = 0; i_d_1 < 2; i_d_1++)
         {
           c_q0[i_g][i_d_0][i_d_1] = 0.0;
-          for(int i_r_0 = 0; i_r_0 < 3; i_r_0++)
+          for(int q_r_0 = 0; q_r_0 < 3; q_r_0++)
           {
-            c_q0[i_g][i_d_0][i_d_1] += c0[i_ele + n_ele * (i_d_0 + 2 * i_r_0)] * d_CG1[i_r_0][i_g][i_d_1];
+            c_q0[i_g][i_d_0][i_d_1] += c0[i_ele + n_ele * (i_d_0 + 2 * q_r_0)] * d_CG1[q_r_0][i_g][i_d_1];
           };
         };
       };
@@ -139,9 +139,9 @@ __global__ void d(int n_ele, double* localTensor, double dt, double* c0)
         for(int i_d_1 = 0; i_d_1 < 2; i_d_1++)
         {
           c_q0[i_g][i_d_0][i_d_1] = 0.0;
-          for(int i_r_0 = 0; i_r_0 < 3; i_r_0++)
+          for(int q_r_0 = 0; q_r_0 < 3; q_r_0++)
           {
-            c_q0[i_g][i_d_0][i_d_1] += c0[i_ele + n_ele * (i_d_0 + 2 * i_r_0)] * d_CG1[i_r_0][i_g][i_d_1];
+            c_q0[i_g][i_d_0][i_d_1] += c0[i_ele + n_ele * (i_d_0 + 2 * q_r_0)] * d_CG1[q_r_0][i_g][i_d_1];
           };
         };
       };
@@ -217,9 +217,9 @@ __global__ void M(int n_ele, double* localTensor, double dt, double* c0)
         for(int i_d_1 = 0; i_d_1 < 2; i_d_1++)
         {
           c_q0[i_g][i_d_0][i_d_1] = 0.0;
-          for(int i_r_0 = 0; i_r_0 < 3; i_r_0++)
+          for(int q_r_0 = 0; q_r_0 < 3; q_r_0++)
           {
-            c_q0[i_g][i_d_0][i_d_1] += c0[i_ele + n_ele * (i_d_0 + 2 * i_r_0)] * d_CG1[i_r_0][i_g][i_d_1];
+            c_q0[i_g][i_d_0][i_d_1] += c0[i_ele + n_ele * (i_d_0 + 2 * q_r_0)] * d_CG1[q_r_0][i_g][i_d_1];
           };
         };
       };
@@ -282,23 +282,23 @@ __global__ void diff_rhs(int n_ele, double* localTensor, double dt, double* c0, 
         for(int i_d_1 = 0; i_d_1 < 2; i_d_1++)
         {
           c_q0[i_g][i_d_0][i_d_1] = 0.0;
-          for(int i_r_0 = 0; i_r_0 < 3; i_r_0++)
+          for(int q_r_0 = 0; q_r_0 < 3; q_r_0++)
           {
-            c_q0[i_g][i_d_0][i_d_1] += c0[i_ele + n_ele * (i_d_0 + 2 * i_r_0)] * d_CG1[i_r_0][i_g][i_d_1];
+            c_q0[i_g][i_d_0][i_d_1] += c0[i_ele + n_ele * (i_d_0 + 2 * q_r_0)] * d_CG1[q_r_0][i_g][i_d_1];
           };
         };
       };
       c_q1[i_g] = 0.0;
-      for(int i_r_0 = 0; i_r_0 < 3; i_r_0++)
+      for(int q_r_0 = 0; q_r_0 < 3; q_r_0++)
       {
-        c_q1[i_g] += c1[i_ele + n_ele * i_r_0] * CG1[i_r_0][i_g];
+        c_q1[i_g] += c1[i_ele + n_ele * q_r_0] * CG1[q_r_0][i_g];
       };
       for(int i_d_0 = 0; i_d_0 < 2; i_d_0++)
       {
         d_c_q1[i_g][i_d_0] = 0.0;
-        for(int i_r_0 = 0; i_r_0 < 3; i_r_0++)
+        for(int q_r_0 = 0; q_r_0 < 3; q_r_0++)
         {
-          d_c_q1[i_g][i_d_0] += c1[i_ele + n_ele * i_r_0] * d_CG1[i_r_0][i_g][i_d_0];
+          d_c_q1[i_g][i_d_0] += c1[i_ele + n_ele * q_r_0] * d_CG1[q_r_0][i_g][i_d_0];
         };
       };
     };
@@ -374,23 +374,23 @@ __global__ void adv_rhs(int n_ele, double* localTensor, double dt, double* c0, d
         for(int i_d_1 = 0; i_d_1 < 2; i_d_1++)
         {
           c_q0[i_g][i_d_0][i_d_1] = 0.0;
-          for(int i_r_0 = 0; i_r_0 < 3; i_r_0++)
+          for(int q_r_0 = 0; q_r_0 < 3; q_r_0++)
           {
-            c_q0[i_g][i_d_0][i_d_1] += c0[i_ele + n_ele * (i_d_0 + 2 * i_r_0)] * d_CG1[i_r_0][i_g][i_d_1];
+            c_q0[i_g][i_d_0][i_d_1] += c0[i_ele + n_ele * (i_d_0 + 2 * q_r_0)] * d_CG1[q_r_0][i_g][i_d_1];
           };
         };
       };
       c_q2[i_g] = 0.0;
-      for(int i_r_0 = 0; i_r_0 < 3; i_r_0++)
+      for(int q_r_0 = 0; q_r_0 < 3; q_r_0++)
       {
-        c_q2[i_g] += c2[i_ele + n_ele * i_r_0] * CG1[i_r_0][i_g];
+        c_q2[i_g] += c2[i_ele + n_ele * q_r_0] * CG1[q_r_0][i_g];
       };
       for(int i_d_0 = 0; i_d_0 < 2; i_d_0++)
       {
         c_q1[i_g][i_d_0] = 0.0;
-        for(int i_r_0 = 0; i_r_0 < 3; i_r_0++)
+        for(int q_r_0 = 0; q_r_0 < 3; q_r_0++)
         {
-          c_q1[i_g][i_d_0] += c1[i_ele + n_ele * (i_d_0 + 2 * i_r_0)] * CG1[i_r_0][i_g];
+          c_q1[i_g][i_d_0] += c1[i_ele + n_ele * (i_d_0 + 2 * q_r_0)] * CG1[q_r_0][i_g];
         };
       };
     };

--- a/tests/expected/cuda/swapped-advection/model.cu
+++ b/tests/expected/cuda/swapped-advection/model.cu
@@ -57,23 +57,23 @@ __global__ void rhs(int n_ele, double* localTensor, double dt, double* c0, doubl
         for(int i_d_1 = 0; i_d_1 < 2; i_d_1++)
         {
           c_q0[i_g][i_d_0][i_d_1] = 0.0;
-          for(int i_r_0 = 0; i_r_0 < 3; i_r_0++)
+          for(int q_r_0 = 0; q_r_0 < 3; q_r_0++)
           {
-            c_q0[i_g][i_d_0][i_d_1] += c0[i_ele + n_ele * (i_d_0 + 2 * i_r_0)] * d_CG1[i_r_0][i_g][i_d_1];
+            c_q0[i_g][i_d_0][i_d_1] += c0[i_ele + n_ele * (i_d_0 + 2 * q_r_0)] * d_CG1[q_r_0][i_g][i_d_1];
           };
         };
       };
       c_q1[i_g] = 0.0;
-      for(int i_r_0 = 0; i_r_0 < 3; i_r_0++)
+      for(int q_r_0 = 0; q_r_0 < 3; q_r_0++)
       {
-        c_q1[i_g] += c1[i_ele + n_ele * i_r_0] * CG1[i_r_0][i_g];
+        c_q1[i_g] += c1[i_ele + n_ele * q_r_0] * CG1[q_r_0][i_g];
       };
       for(int i_d_0 = 0; i_d_0 < 2; i_d_0++)
       {
         c_q2[i_g][i_d_0] = 0.0;
-        for(int i_r_0 = 0; i_r_0 < 3; i_r_0++)
+        for(int q_r_0 = 0; q_r_0 < 3; q_r_0++)
         {
-          c_q2[i_g][i_d_0] += c2[i_ele + n_ele * (i_d_0 + 2 * i_r_0)] * CG1[i_r_0][i_g];
+          c_q2[i_g][i_d_0] += c2[i_ele + n_ele * (i_d_0 + 2 * q_r_0)] * CG1[q_r_0][i_g];
         };
       };
     };
@@ -142,9 +142,9 @@ __global__ void Mass(int n_ele, double* localTensor, double dt, double* c0)
         for(int i_d_1 = 0; i_d_1 < 2; i_d_1++)
         {
           c_q0[i_g][i_d_0][i_d_1] = 0.0;
-          for(int i_r_0 = 0; i_r_0 < 3; i_r_0++)
+          for(int q_r_0 = 0; q_r_0 < 3; q_r_0++)
           {
-            c_q0[i_g][i_d_0][i_d_1] += c0[i_ele + n_ele * (i_d_0 + 2 * i_r_0)] * d_CG1[i_r_0][i_g][i_d_1];
+            c_q0[i_g][i_d_0][i_d_1] += c0[i_ele + n_ele * (i_d_0 + 2 * q_r_0)] * d_CG1[q_r_0][i_g][i_d_1];
           };
         };
       };

--- a/tests/expected/op2/diffusion-1/model.cpp
+++ b/tests/expected/op2/diffusion-1/model.cpp
@@ -4,7 +4,7 @@
 
 
 
-void A(double localTensor[3][3], double dt, double c0[3][2], double c1[3][2][2])
+void A(double* localTensor, double dt, double* c0[2], double* c1[2][2], int i_r_0, int i_r_1)
 {
   const double CG1[3][6] = { {  0.09157621, 0.09157621, 0.81684757,
                                0.44594849, 0.44594849, 0.10810302 },
@@ -43,9 +43,9 @@ void A(double localTensor[3][3], double dt, double c0[3][2], double c1[3][2][2])
       for(int i_d_1 = 0; i_d_1 < 2; i_d_1++)
       {
         c_q1[i_g][i_d_0][i_d_1] = 0.0;
-        for(int i_r_0 = 0; i_r_0 < 3; i_r_0++)
+        for(int q_r_0 = 0; q_r_0 < 3; q_r_0++)
         {
-          c_q1[i_g][i_d_0][i_d_1] += c1[i_r_0][i_d_0][i_d_1] * CG1[i_r_0][i_g];
+          c_q1[i_g][i_d_0][i_d_1] += c1[q_r_0][i_d_0][i_d_1] * CG1[q_r_0][i_g];
         };
       };
     };
@@ -54,47 +54,40 @@ void A(double localTensor[3][3], double dt, double c0[3][2], double c1[3][2][2])
       for(int i_d_1 = 0; i_d_1 < 2; i_d_1++)
       {
         c_q0[i_g][i_d_0][i_d_1] = 0.0;
-        for(int i_r_0 = 0; i_r_0 < 3; i_r_0++)
+        for(int q_r_0 = 0; q_r_0 < 3; q_r_0++)
         {
-          c_q0[i_g][i_d_0][i_d_1] += c0[i_r_0][i_d_0] * d_CG1[i_r_0][i_g][i_d_1];
+          c_q0[i_g][i_d_0][i_d_1] += c0[q_r_0][i_d_0] * d_CG1[q_r_0][i_g][i_d_1];
         };
       };
     };
   };
-  for(int i_r_0 = 0; i_r_0 < 3; i_r_0++)
+  for(int i_g = 0; i_g < 6; i_g++)
   {
-    for(int i_r_1 = 0; i_r_1 < 3; i_r_1++)
+    double ST2 = 0.0;
+    double ST1 = 0.0;
+    double ST0 = 0.0;
+    ST2 += CG1[i_r_0][i_g] * CG1[i_r_1][i_g] * (c_q0[i_g][0][0] * c_q0[i_g][1][1] + -1 * c_q0[i_g][0][1] * c_q0[i_g][1][0]);
+    ST1 += c_q0[i_g][0][0] * c_q0[i_g][1][1] + -1 * c_q0[i_g][0][1] * c_q0[i_g][1][0];
+    double l101[2][2] = { { c_q0[i_g][1][1], -1 * c_q0[i_g][0][1] }, { -1 * c_q0[i_g][1][0], c_q0[i_g][0][0] } };
+    double l50[2][2] = { { c_q0[i_g][1][1], -1 * c_q0[i_g][0][1] }, { -1 * c_q0[i_g][1][0], c_q0[i_g][0][0] } };
+    for(int i_d_1 = 0; i_d_1 < 2; i_d_1++)
     {
-      localTensor[i_r_0][i_r_1] = 0.0;
-      for(int i_g = 0; i_g < 6; i_g++)
+      for(int i_d_0 = 0; i_d_0 < 2; i_d_0++)
       {
-        double ST2 = 0.0;
-        double ST1 = 0.0;
-        double ST0 = 0.0;
-        ST2 += CG1[i_r_0][i_g] * CG1[i_r_1][i_g] * (c_q0[i_g][0][0] * c_q0[i_g][1][1] + -1 * c_q0[i_g][0][1] * c_q0[i_g][1][0]);
-        ST1 += c_q0[i_g][0][0] * c_q0[i_g][1][1] + -1 * c_q0[i_g][0][1] * c_q0[i_g][1][0];
-        double l101[2][2] = { { c_q0[i_g][1][1], -1 * c_q0[i_g][0][1] }, { -1 * c_q0[i_g][1][0], c_q0[i_g][0][0] } };
-        double l50[2][2] = { { c_q0[i_g][1][1], -1 * c_q0[i_g][0][1] }, { -1 * c_q0[i_g][1][0], c_q0[i_g][0][0] } };
-        for(int i_d_1 = 0; i_d_1 < 2; i_d_1++)
+        for(int i_d_5 = 0; i_d_5 < 2; i_d_5++)
         {
-          for(int i_d_0 = 0; i_d_0 < 2; i_d_0++)
+          for(int i_d_10 = 0; i_d_10 < 2; i_d_10++)
           {
-            for(int i_d_5 = 0; i_d_5 < 2; i_d_5++)
-            {
-              for(int i_d_10 = 0; i_d_10 < 2; i_d_10++)
-              {
-                ST0 += c_q1[i_g][i_d_0][i_d_1] * -1 * (l50[i_d_5][i_d_0] / (c_q0[i_g][0][0] * c_q0[i_g][1][1] + -1 * c_q0[i_g][0][1] * c_q0[i_g][1][0])) * d_CG1[i_r_0][i_g][i_d_5] * (l101[i_d_10][i_d_1] / (c_q0[i_g][0][0] * c_q0[i_g][1][1] + -1 * c_q0[i_g][0][1] * c_q0[i_g][1][0])) * d_CG1[i_r_1][i_g][i_d_10];
-              };
-            };
+            ST0 += c_q1[i_g][i_d_0][i_d_1] * -1 * (l50[i_d_5][i_d_0] / (c_q0[i_g][0][0] * c_q0[i_g][1][1] + -1 * c_q0[i_g][0][1] * c_q0[i_g][1][0])) * d_CG1[i_r_0][i_g][i_d_5] * (l101[i_d_10][i_d_1] / (c_q0[i_g][0][0] * c_q0[i_g][1][1] + -1 * c_q0[i_g][0][1] * c_q0[i_g][1][0])) * d_CG1[i_r_1][i_g][i_d_10];
           };
         };
-        localTensor[i_r_0][i_r_1] += (-1 * 0.5 * ST0 * ST1 + ST2) * w[i_g];
       };
     };
+    localTensor[0] += (-1 * 0.5 * ST0 * ST1 + ST2) * w[i_g];
   };
 }
 
-void d(double localTensor[3][3], double dt, double c0[3][2], double c1[3][2][2])
+void d(double* localTensor, double dt, double* c0[2], double* c1[2][2], int i_r_0, int i_r_1)
 {
   const double CG1[3][6] = { {  0.09157621, 0.09157621, 0.81684757,
                                0.44594849, 0.44594849, 0.10810302 },
@@ -133,9 +126,9 @@ void d(double localTensor[3][3], double dt, double c0[3][2], double c1[3][2][2])
       for(int i_d_1 = 0; i_d_1 < 2; i_d_1++)
       {
         c_q1[i_g][i_d_0][i_d_1] = 0.0;
-        for(int i_r_0 = 0; i_r_0 < 3; i_r_0++)
+        for(int q_r_0 = 0; q_r_0 < 3; q_r_0++)
         {
-          c_q1[i_g][i_d_0][i_d_1] += c1[i_r_0][i_d_0][i_d_1] * CG1[i_r_0][i_g];
+          c_q1[i_g][i_d_0][i_d_1] += c1[q_r_0][i_d_0][i_d_1] * CG1[q_r_0][i_g];
         };
       };
     };
@@ -144,45 +137,38 @@ void d(double localTensor[3][3], double dt, double c0[3][2], double c1[3][2][2])
       for(int i_d_1 = 0; i_d_1 < 2; i_d_1++)
       {
         c_q0[i_g][i_d_0][i_d_1] = 0.0;
-        for(int i_r_0 = 0; i_r_0 < 3; i_r_0++)
+        for(int q_r_0 = 0; q_r_0 < 3; q_r_0++)
         {
-          c_q0[i_g][i_d_0][i_d_1] += c0[i_r_0][i_d_0] * d_CG1[i_r_0][i_g][i_d_1];
+          c_q0[i_g][i_d_0][i_d_1] += c0[q_r_0][i_d_0] * d_CG1[q_r_0][i_g][i_d_1];
         };
       };
     };
   };
-  for(int i_r_0 = 0; i_r_0 < 3; i_r_0++)
+  for(int i_g = 0; i_g < 6; i_g++)
   {
-    for(int i_r_1 = 0; i_r_1 < 3; i_r_1++)
+    double ST8 = 0.0;
+    double ST7 = 0.0;
+    ST8 += c_q0[i_g][0][0] * c_q0[i_g][1][1] + -1 * c_q0[i_g][0][1] * c_q0[i_g][1][0];
+    double l101[2][2] = { { c_q0[i_g][1][1], -1 * c_q0[i_g][0][1] }, { -1 * c_q0[i_g][1][0], c_q0[i_g][0][0] } };
+    double l50[2][2] = { { c_q0[i_g][1][1], -1 * c_q0[i_g][0][1] }, { -1 * c_q0[i_g][1][0], c_q0[i_g][0][0] } };
+    for(int i_d_1 = 0; i_d_1 < 2; i_d_1++)
     {
-      localTensor[i_r_0][i_r_1] = 0.0;
-      for(int i_g = 0; i_g < 6; i_g++)
+      for(int i_d_0 = 0; i_d_0 < 2; i_d_0++)
       {
-        double ST8 = 0.0;
-        double ST7 = 0.0;
-        ST8 += c_q0[i_g][0][0] * c_q0[i_g][1][1] + -1 * c_q0[i_g][0][1] * c_q0[i_g][1][0];
-        double l101[2][2] = { { c_q0[i_g][1][1], -1 * c_q0[i_g][0][1] }, { -1 * c_q0[i_g][1][0], c_q0[i_g][0][0] } };
-        double l50[2][2] = { { c_q0[i_g][1][1], -1 * c_q0[i_g][0][1] }, { -1 * c_q0[i_g][1][0], c_q0[i_g][0][0] } };
-        for(int i_d_1 = 0; i_d_1 < 2; i_d_1++)
+        for(int i_d_5 = 0; i_d_5 < 2; i_d_5++)
         {
-          for(int i_d_0 = 0; i_d_0 < 2; i_d_0++)
+          for(int i_d_10 = 0; i_d_10 < 2; i_d_10++)
           {
-            for(int i_d_5 = 0; i_d_5 < 2; i_d_5++)
-            {
-              for(int i_d_10 = 0; i_d_10 < 2; i_d_10++)
-              {
-                ST7 += c_q1[i_g][i_d_0][i_d_1] * -1 * (l50[i_d_5][i_d_0] / (c_q0[i_g][0][0] * c_q0[i_g][1][1] + -1 * c_q0[i_g][0][1] * c_q0[i_g][1][0])) * d_CG1[i_r_0][i_g][i_d_5] * (l101[i_d_10][i_d_1] / (c_q0[i_g][0][0] * c_q0[i_g][1][1] + -1 * c_q0[i_g][0][1] * c_q0[i_g][1][0])) * d_CG1[i_r_1][i_g][i_d_10];
-              };
-            };
+            ST7 += c_q1[i_g][i_d_0][i_d_1] * -1 * (l50[i_d_5][i_d_0] / (c_q0[i_g][0][0] * c_q0[i_g][1][1] + -1 * c_q0[i_g][0][1] * c_q0[i_g][1][0])) * d_CG1[i_r_0][i_g][i_d_5] * (l101[i_d_10][i_d_1] / (c_q0[i_g][0][0] * c_q0[i_g][1][1] + -1 * c_q0[i_g][0][1] * c_q0[i_g][1][0])) * d_CG1[i_r_1][i_g][i_d_10];
           };
         };
-        localTensor[i_r_0][i_r_1] += ST7 * ST8 * w[i_g];
       };
     };
+    localTensor[0] += ST7 * ST8 * w[i_g];
   };
 }
 
-void M(double localTensor[3][3], double dt, double c0[3][2])
+void M(double* localTensor, double dt, double* c0[2], int i_r_0, int i_r_1)
 {
   const double CG1[3][6] = { {  0.09157621, 0.09157621, 0.81684757,
                                0.44594849, 0.44594849, 0.10810302 },
@@ -220,29 +206,22 @@ void M(double localTensor[3][3], double dt, double c0[3][2])
       for(int i_d_1 = 0; i_d_1 < 2; i_d_1++)
       {
         c_q0[i_g][i_d_0][i_d_1] = 0.0;
-        for(int i_r_0 = 0; i_r_0 < 3; i_r_0++)
+        for(int q_r_0 = 0; q_r_0 < 3; q_r_0++)
         {
-          c_q0[i_g][i_d_0][i_d_1] += c0[i_r_0][i_d_0] * d_CG1[i_r_0][i_g][i_d_1];
+          c_q0[i_g][i_d_0][i_d_1] += c0[q_r_0][i_d_0] * d_CG1[q_r_0][i_g][i_d_1];
         };
       };
     };
   };
-  for(int i_r_0 = 0; i_r_0 < 3; i_r_0++)
+  for(int i_g = 0; i_g < 6; i_g++)
   {
-    for(int i_r_1 = 0; i_r_1 < 3; i_r_1++)
-    {
-      localTensor[i_r_0][i_r_1] = 0.0;
-      for(int i_g = 0; i_g < 6; i_g++)
-      {
-        double ST6 = 0.0;
-        ST6 += CG1[i_r_0][i_g] * CG1[i_r_1][i_g] * (c_q0[i_g][0][0] * c_q0[i_g][1][1] + -1 * c_q0[i_g][0][1] * c_q0[i_g][1][0]);
-        localTensor[i_r_0][i_r_1] += ST6 * w[i_g];
-      };
-    };
+    double ST6 = 0.0;
+    ST6 += CG1[i_r_0][i_g] * CG1[i_r_1][i_g] * (c_q0[i_g][0][0] * c_q0[i_g][1][1] + -1 * c_q0[i_g][0][1] * c_q0[i_g][1][0]);
+    localTensor[0] += ST6 * w[i_g];
   };
 }
 
-void rhs(double localTensor[3], double dt, double c0[3][2], double c1[3], double c2[3][2][2])
+void rhs(double** localTensor, double dt, double* c0[2], double* c1, double* c2[2][2])
 {
   const double CG1[3][6] = { {  0.09157621, 0.09157621, 0.81684757,
                                0.44594849, 0.44594849, 0.10810302 },
@@ -283,9 +262,9 @@ void rhs(double localTensor[3], double dt, double c0[3][2], double c1[3], double
       for(int i_d_1 = 0; i_d_1 < 2; i_d_1++)
       {
         c_q2[i_g][i_d_0][i_d_1] = 0.0;
-        for(int i_r_0 = 0; i_r_0 < 3; i_r_0++)
+        for(int q_r_0 = 0; q_r_0 < 3; q_r_0++)
         {
-          c_q2[i_g][i_d_0][i_d_1] += c2[i_r_0][i_d_0][i_d_1] * CG1[i_r_0][i_g];
+          c_q2[i_g][i_d_0][i_d_1] += c2[q_r_0][i_d_0][i_d_1] * CG1[q_r_0][i_g];
         };
       };
     };
@@ -294,29 +273,29 @@ void rhs(double localTensor[3], double dt, double c0[3][2], double c1[3], double
       for(int i_d_1 = 0; i_d_1 < 2; i_d_1++)
       {
         c_q0[i_g][i_d_0][i_d_1] = 0.0;
-        for(int i_r_0 = 0; i_r_0 < 3; i_r_0++)
+        for(int q_r_0 = 0; q_r_0 < 3; q_r_0++)
         {
-          c_q0[i_g][i_d_0][i_d_1] += c0[i_r_0][i_d_0] * d_CG1[i_r_0][i_g][i_d_1];
+          c_q0[i_g][i_d_0][i_d_1] += c0[q_r_0][i_d_0] * d_CG1[q_r_0][i_g][i_d_1];
         };
       };
     };
     c_q1[i_g] = 0.0;
-    for(int i_r_0 = 0; i_r_0 < 3; i_r_0++)
+    for(int q_r_0 = 0; q_r_0 < 3; q_r_0++)
     {
-      c_q1[i_g] += c1[i_r_0] * CG1[i_r_0][i_g];
+      c_q1[i_g] += c1[q_r_0] * CG1[q_r_0][i_g];
     };
     for(int i_d_0 = 0; i_d_0 < 2; i_d_0++)
     {
       d_c_q1[i_g][i_d_0] = 0.0;
-      for(int i_r_0 = 0; i_r_0 < 3; i_r_0++)
+      for(int q_r_0 = 0; q_r_0 < 3; q_r_0++)
       {
-        d_c_q1[i_g][i_d_0] += c1[i_r_0] * d_CG1[i_r_0][i_g][i_d_0];
+        d_c_q1[i_g][i_d_0] += c1[q_r_0] * d_CG1[q_r_0][i_g][i_d_0];
       };
     };
   };
   for(int i_r_0 = 0; i_r_0 < 3; i_r_0++)
   {
-    localTensor[i_r_0] = 0.0;
+    localTensor[i_r_0][0] = 0.0;
     for(int i_g = 0; i_g < 6; i_g++)
     {
       double ST5 = 0.0;
@@ -339,7 +318,7 @@ void rhs(double localTensor[3], double dt, double c0[3][2], double c1[3], double
           };
         };
       };
-      localTensor[i_r_0] += (0.5 * ST3 * ST4 + ST5) * w[i_g];
+      localTensor[i_r_0][0] += (0.5 * ST3 * ST4 + ST5) * w[i_g];
     };
   };
 }

--- a/tests/expected/op2/diffusion-2/model.cpp
+++ b/tests/expected/op2/diffusion-2/model.cpp
@@ -4,7 +4,7 @@
 
 
 
-void A(double localTensor[3][3], double dt, double c0[3][2], double c1[3][2][2])
+void A(double* localTensor, double dt, double* c0[2], double* c1[2][2], int i_r_0, int i_r_1)
 {
   const double CG1[3][6] = { {  0.09157621, 0.09157621, 0.81684757,
                                0.44594849, 0.44594849, 0.10810302 },
@@ -43,9 +43,9 @@ void A(double localTensor[3][3], double dt, double c0[3][2], double c1[3][2][2])
       for(int i_d_1 = 0; i_d_1 < 2; i_d_1++)
       {
         c_q1[i_g][i_d_0][i_d_1] = 0.0;
-        for(int i_r_0 = 0; i_r_0 < 3; i_r_0++)
+        for(int q_r_0 = 0; q_r_0 < 3; q_r_0++)
         {
-          c_q1[i_g][i_d_0][i_d_1] += c1[i_r_0][i_d_0][i_d_1] * CG1[i_r_0][i_g];
+          c_q1[i_g][i_d_0][i_d_1] += c1[q_r_0][i_d_0][i_d_1] * CG1[q_r_0][i_g];
         };
       };
     };
@@ -54,47 +54,40 @@ void A(double localTensor[3][3], double dt, double c0[3][2], double c1[3][2][2])
       for(int i_d_1 = 0; i_d_1 < 2; i_d_1++)
       {
         c_q0[i_g][i_d_0][i_d_1] = 0.0;
-        for(int i_r_0 = 0; i_r_0 < 3; i_r_0++)
+        for(int q_r_0 = 0; q_r_0 < 3; q_r_0++)
         {
-          c_q0[i_g][i_d_0][i_d_1] += c0[i_r_0][i_d_0] * d_CG1[i_r_0][i_g][i_d_1];
+          c_q0[i_g][i_d_0][i_d_1] += c0[q_r_0][i_d_0] * d_CG1[q_r_0][i_g][i_d_1];
         };
       };
     };
   };
-  for(int i_r_0 = 0; i_r_0 < 3; i_r_0++)
+  for(int i_g = 0; i_g < 6; i_g++)
   {
-    for(int i_r_1 = 0; i_r_1 < 3; i_r_1++)
+    double ST2 = 0.0;
+    double ST1 = 0.0;
+    double ST0 = 0.0;
+    ST2 += CG1[i_r_0][i_g] * CG1[i_r_1][i_g] * (c_q0[i_g][0][0] * c_q0[i_g][1][1] + -1 * c_q0[i_g][0][1] * c_q0[i_g][1][0]);
+    ST1 += c_q0[i_g][0][0] * c_q0[i_g][1][1] + -1 * c_q0[i_g][0][1] * c_q0[i_g][1][0];
+    double l117[2][2] = { { c_q0[i_g][1][1], -1 * c_q0[i_g][0][1] }, { -1 * c_q0[i_g][1][0], c_q0[i_g][0][0] } };
+    double l50[2][2] = { { c_q0[i_g][1][1], -1 * c_q0[i_g][0][1] }, { -1 * c_q0[i_g][1][0], c_q0[i_g][0][0] } };
+    for(int i_d_7 = 0; i_d_7 < 2; i_d_7++)
     {
-      localTensor[i_r_0][i_r_1] = 0.0;
-      for(int i_g = 0; i_g < 6; i_g++)
+      for(int i_d_0 = 0; i_d_0 < 2; i_d_0++)
       {
-        double ST2 = 0.0;
-        double ST1 = 0.0;
-        double ST0 = 0.0;
-        ST2 += CG1[i_r_0][i_g] * CG1[i_r_1][i_g] * (c_q0[i_g][0][0] * c_q0[i_g][1][1] + -1 * c_q0[i_g][0][1] * c_q0[i_g][1][0]);
-        ST1 += c_q0[i_g][0][0] * c_q0[i_g][1][1] + -1 * c_q0[i_g][0][1] * c_q0[i_g][1][0];
-        double l117[2][2] = { { c_q0[i_g][1][1], -1 * c_q0[i_g][0][1] }, { -1 * c_q0[i_g][1][0], c_q0[i_g][0][0] } };
-        double l50[2][2] = { { c_q0[i_g][1][1], -1 * c_q0[i_g][0][1] }, { -1 * c_q0[i_g][1][0], c_q0[i_g][0][0] } };
-        for(int i_d_7 = 0; i_d_7 < 2; i_d_7++)
+        for(int i_d_5 = 0; i_d_5 < 2; i_d_5++)
         {
-          for(int i_d_0 = 0; i_d_0 < 2; i_d_0++)
+          for(int i_d_11 = 0; i_d_11 < 2; i_d_11++)
           {
-            for(int i_d_5 = 0; i_d_5 < 2; i_d_5++)
-            {
-              for(int i_d_11 = 0; i_d_11 < 2; i_d_11++)
-              {
-                ST0 += c_q1[i_g][i_d_0][i_d_1] * (l50[i_d_5][i_d_0] / (c_q0[i_g][0][0] * c_q0[i_g][1][1] + -1 * c_q0[i_g][0][1] * c_q0[i_g][1][0])) * d_CG1[i_r_0][i_g][i_d_5] * (l117[i_d_11][i_d_7] / (c_q0[i_g][0][0] * c_q0[i_g][1][1] + -1 * c_q0[i_g][0][1] * c_q0[i_g][1][0])) * d_CG1[i_r_1][i_g][i_d_11];
-              };
-            };
+            ST0 += c_q1[i_g][i_d_0][i_d_1] * (l50[i_d_5][i_d_0] / (c_q0[i_g][0][0] * c_q0[i_g][1][1] + -1 * c_q0[i_g][0][1] * c_q0[i_g][1][0])) * d_CG1[i_r_0][i_g][i_d_5] * (l117[i_d_11][i_d_7] / (c_q0[i_g][0][0] * c_q0[i_g][1][1] + -1 * c_q0[i_g][0][1] * c_q0[i_g][1][0])) * d_CG1[i_r_1][i_g][i_d_11];
           };
         };
-        localTensor[i_r_0][i_r_1] += (-1 * 0.5 * -1 * ST0 * ST1 + ST2) * w[i_g];
       };
     };
+    localTensor[0] += (-1 * 0.5 * -1 * ST0 * ST1 + ST2) * w[i_g];
   };
 }
 
-void d(double localTensor[3][3], double dt, double c0[3][2], double c1[3][2][2])
+void d(double* localTensor, double dt, double* c0[2], double* c1[2][2], int i_r_0, int i_r_1)
 {
   const double CG1[3][6] = { {  0.09157621, 0.09157621, 0.81684757,
                                0.44594849, 0.44594849, 0.10810302 },
@@ -133,9 +126,9 @@ void d(double localTensor[3][3], double dt, double c0[3][2], double c1[3][2][2])
       for(int i_d_1 = 0; i_d_1 < 2; i_d_1++)
       {
         c_q1[i_g][i_d_0][i_d_1] = 0.0;
-        for(int i_r_0 = 0; i_r_0 < 3; i_r_0++)
+        for(int q_r_0 = 0; q_r_0 < 3; q_r_0++)
         {
-          c_q1[i_g][i_d_0][i_d_1] += c1[i_r_0][i_d_0][i_d_1] * CG1[i_r_0][i_g];
+          c_q1[i_g][i_d_0][i_d_1] += c1[q_r_0][i_d_0][i_d_1] * CG1[q_r_0][i_g];
         };
       };
     };
@@ -144,45 +137,38 @@ void d(double localTensor[3][3], double dt, double c0[3][2], double c1[3][2][2])
       for(int i_d_1 = 0; i_d_1 < 2; i_d_1++)
       {
         c_q0[i_g][i_d_0][i_d_1] = 0.0;
-        for(int i_r_0 = 0; i_r_0 < 3; i_r_0++)
+        for(int q_r_0 = 0; q_r_0 < 3; q_r_0++)
         {
-          c_q0[i_g][i_d_0][i_d_1] += c0[i_r_0][i_d_0] * d_CG1[i_r_0][i_g][i_d_1];
+          c_q0[i_g][i_d_0][i_d_1] += c0[q_r_0][i_d_0] * d_CG1[q_r_0][i_g][i_d_1];
         };
       };
     };
   };
-  for(int i_r_0 = 0; i_r_0 < 3; i_r_0++)
+  for(int i_g = 0; i_g < 6; i_g++)
   {
-    for(int i_r_1 = 0; i_r_1 < 3; i_r_1++)
+    double ST8 = 0.0;
+    double ST7 = 0.0;
+    ST8 += c_q0[i_g][0][0] * c_q0[i_g][1][1] + -1 * c_q0[i_g][0][1] * c_q0[i_g][1][0];
+    double l117[2][2] = { { c_q0[i_g][1][1], -1 * c_q0[i_g][0][1] }, { -1 * c_q0[i_g][1][0], c_q0[i_g][0][0] } };
+    double l50[2][2] = { { c_q0[i_g][1][1], -1 * c_q0[i_g][0][1] }, { -1 * c_q0[i_g][1][0], c_q0[i_g][0][0] } };
+    for(int i_d_7 = 0; i_d_7 < 2; i_d_7++)
     {
-      localTensor[i_r_0][i_r_1] = 0.0;
-      for(int i_g = 0; i_g < 6; i_g++)
+      for(int i_d_0 = 0; i_d_0 < 2; i_d_0++)
       {
-        double ST8 = 0.0;
-        double ST7 = 0.0;
-        ST8 += c_q0[i_g][0][0] * c_q0[i_g][1][1] + -1 * c_q0[i_g][0][1] * c_q0[i_g][1][0];
-        double l117[2][2] = { { c_q0[i_g][1][1], -1 * c_q0[i_g][0][1] }, { -1 * c_q0[i_g][1][0], c_q0[i_g][0][0] } };
-        double l50[2][2] = { { c_q0[i_g][1][1], -1 * c_q0[i_g][0][1] }, { -1 * c_q0[i_g][1][0], c_q0[i_g][0][0] } };
-        for(int i_d_7 = 0; i_d_7 < 2; i_d_7++)
+        for(int i_d_5 = 0; i_d_5 < 2; i_d_5++)
         {
-          for(int i_d_0 = 0; i_d_0 < 2; i_d_0++)
+          for(int i_d_11 = 0; i_d_11 < 2; i_d_11++)
           {
-            for(int i_d_5 = 0; i_d_5 < 2; i_d_5++)
-            {
-              for(int i_d_11 = 0; i_d_11 < 2; i_d_11++)
-              {
-                ST7 += c_q1[i_g][i_d_0][i_d_1] * (l50[i_d_5][i_d_0] / (c_q0[i_g][0][0] * c_q0[i_g][1][1] + -1 * c_q0[i_g][0][1] * c_q0[i_g][1][0])) * d_CG1[i_r_0][i_g][i_d_5] * (l117[i_d_11][i_d_7] / (c_q0[i_g][0][0] * c_q0[i_g][1][1] + -1 * c_q0[i_g][0][1] * c_q0[i_g][1][0])) * d_CG1[i_r_1][i_g][i_d_11];
-              };
-            };
+            ST7 += c_q1[i_g][i_d_0][i_d_1] * (l50[i_d_5][i_d_0] / (c_q0[i_g][0][0] * c_q0[i_g][1][1] + -1 * c_q0[i_g][0][1] * c_q0[i_g][1][0])) * d_CG1[i_r_0][i_g][i_d_5] * (l117[i_d_11][i_d_7] / (c_q0[i_g][0][0] * c_q0[i_g][1][1] + -1 * c_q0[i_g][0][1] * c_q0[i_g][1][0])) * d_CG1[i_r_1][i_g][i_d_11];
           };
         };
-        localTensor[i_r_0][i_r_1] += -1 * ST7 * ST8 * w[i_g];
       };
     };
+    localTensor[0] += -1 * ST7 * ST8 * w[i_g];
   };
 }
 
-void M(double localTensor[3][3], double dt, double c0[3][2])
+void M(double* localTensor, double dt, double* c0[2], int i_r_0, int i_r_1)
 {
   const double CG1[3][6] = { {  0.09157621, 0.09157621, 0.81684757,
                                0.44594849, 0.44594849, 0.10810302 },
@@ -220,29 +206,22 @@ void M(double localTensor[3][3], double dt, double c0[3][2])
       for(int i_d_1 = 0; i_d_1 < 2; i_d_1++)
       {
         c_q0[i_g][i_d_0][i_d_1] = 0.0;
-        for(int i_r_0 = 0; i_r_0 < 3; i_r_0++)
+        for(int q_r_0 = 0; q_r_0 < 3; q_r_0++)
         {
-          c_q0[i_g][i_d_0][i_d_1] += c0[i_r_0][i_d_0] * d_CG1[i_r_0][i_g][i_d_1];
+          c_q0[i_g][i_d_0][i_d_1] += c0[q_r_0][i_d_0] * d_CG1[q_r_0][i_g][i_d_1];
         };
       };
     };
   };
-  for(int i_r_0 = 0; i_r_0 < 3; i_r_0++)
+  for(int i_g = 0; i_g < 6; i_g++)
   {
-    for(int i_r_1 = 0; i_r_1 < 3; i_r_1++)
-    {
-      localTensor[i_r_0][i_r_1] = 0.0;
-      for(int i_g = 0; i_g < 6; i_g++)
-      {
-        double ST6 = 0.0;
-        ST6 += CG1[i_r_0][i_g] * CG1[i_r_1][i_g] * (c_q0[i_g][0][0] * c_q0[i_g][1][1] + -1 * c_q0[i_g][0][1] * c_q0[i_g][1][0]);
-        localTensor[i_r_0][i_r_1] += ST6 * w[i_g];
-      };
-    };
+    double ST6 = 0.0;
+    ST6 += CG1[i_r_0][i_g] * CG1[i_r_1][i_g] * (c_q0[i_g][0][0] * c_q0[i_g][1][1] + -1 * c_q0[i_g][0][1] * c_q0[i_g][1][0]);
+    localTensor[0] += ST6 * w[i_g];
   };
 }
 
-void rhs(double localTensor[3], double dt, double c0[3][2], double c1[3], double c2[3][2][2])
+void rhs(double** localTensor, double dt, double* c0[2], double* c1, double* c2[2][2])
 {
   const double CG1[3][6] = { {  0.09157621, 0.09157621, 0.81684757,
                                0.44594849, 0.44594849, 0.10810302 },
@@ -283,9 +262,9 @@ void rhs(double localTensor[3], double dt, double c0[3][2], double c1[3], double
       for(int i_d_1 = 0; i_d_1 < 2; i_d_1++)
       {
         c_q2[i_g][i_d_0][i_d_1] = 0.0;
-        for(int i_r_0 = 0; i_r_0 < 3; i_r_0++)
+        for(int q_r_0 = 0; q_r_0 < 3; q_r_0++)
         {
-          c_q2[i_g][i_d_0][i_d_1] += c2[i_r_0][i_d_0][i_d_1] * CG1[i_r_0][i_g];
+          c_q2[i_g][i_d_0][i_d_1] += c2[q_r_0][i_d_0][i_d_1] * CG1[q_r_0][i_g];
         };
       };
     };
@@ -294,29 +273,29 @@ void rhs(double localTensor[3], double dt, double c0[3][2], double c1[3], double
       for(int i_d_1 = 0; i_d_1 < 2; i_d_1++)
       {
         c_q0[i_g][i_d_0][i_d_1] = 0.0;
-        for(int i_r_0 = 0; i_r_0 < 3; i_r_0++)
+        for(int q_r_0 = 0; q_r_0 < 3; q_r_0++)
         {
-          c_q0[i_g][i_d_0][i_d_1] += c0[i_r_0][i_d_0] * d_CG1[i_r_0][i_g][i_d_1];
+          c_q0[i_g][i_d_0][i_d_1] += c0[q_r_0][i_d_0] * d_CG1[q_r_0][i_g][i_d_1];
         };
       };
     };
     c_q1[i_g] = 0.0;
-    for(int i_r_0 = 0; i_r_0 < 3; i_r_0++)
+    for(int q_r_0 = 0; q_r_0 < 3; q_r_0++)
     {
-      c_q1[i_g] += c1[i_r_0] * CG1[i_r_0][i_g];
+      c_q1[i_g] += c1[q_r_0] * CG1[q_r_0][i_g];
     };
     for(int i_d_0 = 0; i_d_0 < 2; i_d_0++)
     {
       d_c_q1[i_g][i_d_0] = 0.0;
-      for(int i_r_0 = 0; i_r_0 < 3; i_r_0++)
+      for(int q_r_0 = 0; q_r_0 < 3; q_r_0++)
       {
-        d_c_q1[i_g][i_d_0] += c1[i_r_0] * d_CG1[i_r_0][i_g][i_d_0];
+        d_c_q1[i_g][i_d_0] += c1[q_r_0] * d_CG1[q_r_0][i_g][i_d_0];
       };
     };
   };
   for(int i_r_0 = 0; i_r_0 < 3; i_r_0++)
   {
-    localTensor[i_r_0] = 0.0;
+    localTensor[i_r_0][0] = 0.0;
     for(int i_g = 0; i_g < 6; i_g++)
     {
       double ST5 = 0.0;
@@ -339,7 +318,7 @@ void rhs(double localTensor[3], double dt, double c0[3][2], double c1[3], double
           };
         };
       };
-      localTensor[i_r_0] += (0.5 * -1 * ST3 * ST4 + ST5) * w[i_g];
+      localTensor[i_r_0][0] += (0.5 * -1 * ST3 * ST4 + ST5) * w[i_g];
     };
   };
 }

--- a/tests/expected/op2/diffusion-3/FluidTracer.cpp
+++ b/tests/expected/op2/diffusion-3/FluidTracer.cpp
@@ -4,7 +4,7 @@
 
 
 
-void A(double localTensor[3][3], double dt, double c0[3][2])
+void A(double* localTensor, double dt, double* c0[2], int i_r_0, int i_r_1)
 {
   const double CG1[3][6] = { {  0.09157621, 0.09157621, 0.81684757,
                                0.44594849, 0.44594849, 0.10810302 },
@@ -42,46 +42,39 @@ void A(double localTensor[3][3], double dt, double c0[3][2])
       for(int i_d_1 = 0; i_d_1 < 2; i_d_1++)
       {
         c_q0[i_g][i_d_0][i_d_1] = 0.0;
-        for(int i_r_0 = 0; i_r_0 < 3; i_r_0++)
+        for(int q_r_0 = 0; q_r_0 < 3; q_r_0++)
         {
-          c_q0[i_g][i_d_0][i_d_1] += c0[i_r_0][i_d_0] * d_CG1[i_r_0][i_g][i_d_1];
+          c_q0[i_g][i_d_0][i_d_1] += c0[q_r_0][i_d_0] * d_CG1[q_r_0][i_g][i_d_1];
         };
       };
     };
   };
-  for(int i_r_0 = 0; i_r_0 < 3; i_r_0++)
+  for(int i_g = 0; i_g < 6; i_g++)
   {
-    for(int i_r_1 = 0; i_r_1 < 3; i_r_1++)
+    double ST3 = 0.0;
+    double ST2 = 0.0;
+    double ST1 = 0.0;
+    double ST0 = 0.0;
+    ST3 += CG1[i_r_0][i_g] * CG1[i_r_1][i_g] * (c_q0[i_g][0][0] * c_q0[i_g][1][1] + -1 * c_q0[i_g][0][1] * c_q0[i_g][1][0]);
+    ST2 += c_q0[i_g][0][0] * c_q0[i_g][1][1] + -1 * c_q0[i_g][0][1] * c_q0[i_g][1][0];
+    ST1 += 0.1 * -1 * dt;
+    double l95[2][2] = { { c_q0[i_g][1][1], -1 * c_q0[i_g][0][1] }, { -1 * c_q0[i_g][1][0], c_q0[i_g][0][0] } };
+    double l35[2][2] = { { c_q0[i_g][1][1], -1 * c_q0[i_g][0][1] }, { -1 * c_q0[i_g][1][0], c_q0[i_g][0][0] } };
+    for(int i_d_5 = 0; i_d_5 < 2; i_d_5++)
     {
-      localTensor[i_r_0][i_r_1] = 0.0;
-      for(int i_g = 0; i_g < 6; i_g++)
+      for(int i_d_3 = 0; i_d_3 < 2; i_d_3++)
       {
-        double ST3 = 0.0;
-        double ST2 = 0.0;
-        double ST1 = 0.0;
-        double ST0 = 0.0;
-        ST3 += CG1[i_r_0][i_g] * CG1[i_r_1][i_g] * (c_q0[i_g][0][0] * c_q0[i_g][1][1] + -1 * c_q0[i_g][0][1] * c_q0[i_g][1][0]);
-        ST2 += c_q0[i_g][0][0] * c_q0[i_g][1][1] + -1 * c_q0[i_g][0][1] * c_q0[i_g][1][0];
-        ST1 += 0.1 * -1 * dt;
-        double l95[2][2] = { { c_q0[i_g][1][1], -1 * c_q0[i_g][0][1] }, { -1 * c_q0[i_g][1][0], c_q0[i_g][0][0] } };
-        double l35[2][2] = { { c_q0[i_g][1][1], -1 * c_q0[i_g][0][1] }, { -1 * c_q0[i_g][1][0], c_q0[i_g][0][0] } };
-        for(int i_d_5 = 0; i_d_5 < 2; i_d_5++)
+        for(int i_d_9 = 0; i_d_9 < 2; i_d_9++)
         {
-          for(int i_d_3 = 0; i_d_3 < 2; i_d_3++)
-          {
-            for(int i_d_9 = 0; i_d_9 < 2; i_d_9++)
-            {
-              ST0 += (l35[i_d_3][i_d_5] / (c_q0[i_g][0][0] * c_q0[i_g][1][1] + -1 * c_q0[i_g][0][1] * c_q0[i_g][1][0])) * d_CG1[i_r_0][i_g][i_d_3] * (l95[i_d_9][i_d_5] / (c_q0[i_g][0][0] * c_q0[i_g][1][1] + -1 * c_q0[i_g][0][1] * c_q0[i_g][1][0])) * d_CG1[i_r_1][i_g][i_d_9];
-            };
-          };
+          ST0 += (l35[i_d_3][i_d_5] / (c_q0[i_g][0][0] * c_q0[i_g][1][1] + -1 * c_q0[i_g][0][1] * c_q0[i_g][1][0])) * d_CG1[i_r_0][i_g][i_d_3] * (l95[i_d_9][i_d_5] / (c_q0[i_g][0][0] * c_q0[i_g][1][1] + -1 * c_q0[i_g][0][1] * c_q0[i_g][1][0])) * d_CG1[i_r_1][i_g][i_d_9];
         };
-        localTensor[i_r_0][i_r_1] += (-1 * 0.5 * ST0 * ST1 * ST2 + ST3) * w[i_g];
       };
     };
+    localTensor[0] += (-1 * 0.5 * ST0 * ST1 * ST2 + ST3) * w[i_g];
   };
 }
 
-void d(double localTensor[3][3], double dt, double c0[3][2])
+void d(double* localTensor, double dt, double* c0[2], int i_r_0, int i_r_1)
 {
   const double CG1[3][6] = { {  0.09157621, 0.09157621, 0.81684757,
                                0.44594849, 0.44594849, 0.10810302 },
@@ -119,44 +112,37 @@ void d(double localTensor[3][3], double dt, double c0[3][2])
       for(int i_d_1 = 0; i_d_1 < 2; i_d_1++)
       {
         c_q0[i_g][i_d_0][i_d_1] = 0.0;
-        for(int i_r_0 = 0; i_r_0 < 3; i_r_0++)
+        for(int q_r_0 = 0; q_r_0 < 3; q_r_0++)
         {
-          c_q0[i_g][i_d_0][i_d_1] += c0[i_r_0][i_d_0] * d_CG1[i_r_0][i_g][i_d_1];
+          c_q0[i_g][i_d_0][i_d_1] += c0[q_r_0][i_d_0] * d_CG1[q_r_0][i_g][i_d_1];
         };
       };
     };
   };
-  for(int i_r_0 = 0; i_r_0 < 3; i_r_0++)
+  for(int i_g = 0; i_g < 6; i_g++)
   {
-    for(int i_r_1 = 0; i_r_1 < 3; i_r_1++)
+    double ST11 = 0.0;
+    double ST10 = 0.0;
+    double ST9 = 0.0;
+    ST11 += c_q0[i_g][0][0] * c_q0[i_g][1][1] + -1 * c_q0[i_g][0][1] * c_q0[i_g][1][0];
+    ST10 += 0.1 * -1 * dt;
+    double l95[2][2] = { { c_q0[i_g][1][1], -1 * c_q0[i_g][0][1] }, { -1 * c_q0[i_g][1][0], c_q0[i_g][0][0] } };
+    double l35[2][2] = { { c_q0[i_g][1][1], -1 * c_q0[i_g][0][1] }, { -1 * c_q0[i_g][1][0], c_q0[i_g][0][0] } };
+    for(int i_d_5 = 0; i_d_5 < 2; i_d_5++)
     {
-      localTensor[i_r_0][i_r_1] = 0.0;
-      for(int i_g = 0; i_g < 6; i_g++)
+      for(int i_d_3 = 0; i_d_3 < 2; i_d_3++)
       {
-        double ST11 = 0.0;
-        double ST10 = 0.0;
-        double ST9 = 0.0;
-        ST11 += c_q0[i_g][0][0] * c_q0[i_g][1][1] + -1 * c_q0[i_g][0][1] * c_q0[i_g][1][0];
-        ST10 += 0.1 * -1 * dt;
-        double l95[2][2] = { { c_q0[i_g][1][1], -1 * c_q0[i_g][0][1] }, { -1 * c_q0[i_g][1][0], c_q0[i_g][0][0] } };
-        double l35[2][2] = { { c_q0[i_g][1][1], -1 * c_q0[i_g][0][1] }, { -1 * c_q0[i_g][1][0], c_q0[i_g][0][0] } };
-        for(int i_d_5 = 0; i_d_5 < 2; i_d_5++)
+        for(int i_d_9 = 0; i_d_9 < 2; i_d_9++)
         {
-          for(int i_d_3 = 0; i_d_3 < 2; i_d_3++)
-          {
-            for(int i_d_9 = 0; i_d_9 < 2; i_d_9++)
-            {
-              ST9 += (l35[i_d_3][i_d_5] / (c_q0[i_g][0][0] * c_q0[i_g][1][1] + -1 * c_q0[i_g][0][1] * c_q0[i_g][1][0])) * d_CG1[i_r_0][i_g][i_d_3] * (l95[i_d_9][i_d_5] / (c_q0[i_g][0][0] * c_q0[i_g][1][1] + -1 * c_q0[i_g][0][1] * c_q0[i_g][1][0])) * d_CG1[i_r_1][i_g][i_d_9];
-            };
-          };
+          ST9 += (l35[i_d_3][i_d_5] / (c_q0[i_g][0][0] * c_q0[i_g][1][1] + -1 * c_q0[i_g][0][1] * c_q0[i_g][1][0])) * d_CG1[i_r_0][i_g][i_d_3] * (l95[i_d_9][i_d_5] / (c_q0[i_g][0][0] * c_q0[i_g][1][1] + -1 * c_q0[i_g][0][1] * c_q0[i_g][1][0])) * d_CG1[i_r_1][i_g][i_d_9];
         };
-        localTensor[i_r_0][i_r_1] += ST9 * ST10 * ST11 * w[i_g];
       };
     };
+    localTensor[0] += ST9 * ST10 * ST11 * w[i_g];
   };
 }
 
-void M(double localTensor[3][3], double dt, double c0[3][2])
+void M(double* localTensor, double dt, double* c0[2], int i_r_0, int i_r_1)
 {
   const double CG1[3][6] = { {  0.09157621, 0.09157621, 0.81684757,
                                0.44594849, 0.44594849, 0.10810302 },
@@ -194,29 +180,22 @@ void M(double localTensor[3][3], double dt, double c0[3][2])
       for(int i_d_1 = 0; i_d_1 < 2; i_d_1++)
       {
         c_q0[i_g][i_d_0][i_d_1] = 0.0;
-        for(int i_r_0 = 0; i_r_0 < 3; i_r_0++)
+        for(int q_r_0 = 0; q_r_0 < 3; q_r_0++)
         {
-          c_q0[i_g][i_d_0][i_d_1] += c0[i_r_0][i_d_0] * d_CG1[i_r_0][i_g][i_d_1];
+          c_q0[i_g][i_d_0][i_d_1] += c0[q_r_0][i_d_0] * d_CG1[q_r_0][i_g][i_d_1];
         };
       };
     };
   };
-  for(int i_r_0 = 0; i_r_0 < 3; i_r_0++)
+  for(int i_g = 0; i_g < 6; i_g++)
   {
-    for(int i_r_1 = 0; i_r_1 < 3; i_r_1++)
-    {
-      localTensor[i_r_0][i_r_1] = 0.0;
-      for(int i_g = 0; i_g < 6; i_g++)
-      {
-        double ST8 = 0.0;
-        ST8 += CG1[i_r_0][i_g] * CG1[i_r_1][i_g] * (c_q0[i_g][0][0] * c_q0[i_g][1][1] + -1 * c_q0[i_g][0][1] * c_q0[i_g][1][0]);
-        localTensor[i_r_0][i_r_1] += ST8 * w[i_g];
-      };
-    };
+    double ST8 = 0.0;
+    ST8 += CG1[i_r_0][i_g] * CG1[i_r_1][i_g] * (c_q0[i_g][0][0] * c_q0[i_g][1][1] + -1 * c_q0[i_g][0][1] * c_q0[i_g][1][0]);
+    localTensor[0] += ST8 * w[i_g];
   };
 }
 
-void rhs(double localTensor[3], double dt, double c0[3][2], double c1[3])
+void rhs(double** localTensor, double dt, double* c0[2], double* c1)
 {
   const double CG1[3][6] = { {  0.09157621, 0.09157621, 0.81684757,
                                0.44594849, 0.44594849, 0.10810302 },
@@ -256,29 +235,29 @@ void rhs(double localTensor[3], double dt, double c0[3][2], double c1[3])
       for(int i_d_1 = 0; i_d_1 < 2; i_d_1++)
       {
         c_q0[i_g][i_d_0][i_d_1] = 0.0;
-        for(int i_r_0 = 0; i_r_0 < 3; i_r_0++)
+        for(int q_r_0 = 0; q_r_0 < 3; q_r_0++)
         {
-          c_q0[i_g][i_d_0][i_d_1] += c0[i_r_0][i_d_0] * d_CG1[i_r_0][i_g][i_d_1];
+          c_q0[i_g][i_d_0][i_d_1] += c0[q_r_0][i_d_0] * d_CG1[q_r_0][i_g][i_d_1];
         };
       };
     };
     c_q1[i_g] = 0.0;
-    for(int i_r_0 = 0; i_r_0 < 3; i_r_0++)
+    for(int q_r_0 = 0; q_r_0 < 3; q_r_0++)
     {
-      c_q1[i_g] += c1[i_r_0] * CG1[i_r_0][i_g];
+      c_q1[i_g] += c1[q_r_0] * CG1[q_r_0][i_g];
     };
     for(int i_d_0 = 0; i_d_0 < 2; i_d_0++)
     {
       d_c_q1[i_g][i_d_0] = 0.0;
-      for(int i_r_0 = 0; i_r_0 < 3; i_r_0++)
+      for(int q_r_0 = 0; q_r_0 < 3; q_r_0++)
       {
-        d_c_q1[i_g][i_d_0] += c1[i_r_0] * d_CG1[i_r_0][i_g][i_d_0];
+        d_c_q1[i_g][i_d_0] += c1[q_r_0] * d_CG1[q_r_0][i_g][i_d_0];
       };
     };
   };
   for(int i_r_0 = 0; i_r_0 < 3; i_r_0++)
   {
-    localTensor[i_r_0] = 0.0;
+    localTensor[i_r_0][0] = 0.0;
     for(int i_g = 0; i_g < 6; i_g++)
     {
       double ST7 = 0.0;
@@ -300,7 +279,7 @@ void rhs(double localTensor[3], double dt, double c0[3][2], double c1[3])
           };
         };
       };
-      localTensor[i_r_0] += (0.5 * ST4 * ST5 * ST6 + ST7) * w[i_g];
+      localTensor[i_r_0][0] += (0.5 * ST4 * ST5 * ST6 + ST7) * w[i_g];
     };
   };
 }

--- a/tests/expected/op2/euler-advection/FluidTracer.cpp
+++ b/tests/expected/op2/euler-advection/FluidTracer.cpp
@@ -4,7 +4,7 @@
 
 
 
-void rhs(double localTensor[3], double dt, double c0[3][2], double c1[3], double c2[3][2])
+void rhs(double** localTensor, double dt, double* c0[2], double* c1, double* c2[2])
 {
   const double CG1[3][6] = { {  0.09157621, 0.09157621, 0.81684757,
                                0.44594849, 0.44594849, 0.10810302 },
@@ -44,29 +44,29 @@ void rhs(double localTensor[3], double dt, double c0[3][2], double c1[3], double
       for(int i_d_1 = 0; i_d_1 < 2; i_d_1++)
       {
         c_q0[i_g][i_d_0][i_d_1] = 0.0;
-        for(int i_r_0 = 0; i_r_0 < 3; i_r_0++)
+        for(int q_r_0 = 0; q_r_0 < 3; q_r_0++)
         {
-          c_q0[i_g][i_d_0][i_d_1] += c0[i_r_0][i_d_0] * d_CG1[i_r_0][i_g][i_d_1];
+          c_q0[i_g][i_d_0][i_d_1] += c0[q_r_0][i_d_0] * d_CG1[q_r_0][i_g][i_d_1];
         };
       };
     };
     c_q1[i_g] = 0.0;
-    for(int i_r_0 = 0; i_r_0 < 3; i_r_0++)
+    for(int q_r_0 = 0; q_r_0 < 3; q_r_0++)
     {
-      c_q1[i_g] += c1[i_r_0] * CG1[i_r_0][i_g];
+      c_q1[i_g] += c1[q_r_0] * CG1[q_r_0][i_g];
     };
     for(int i_d_0 = 0; i_d_0 < 2; i_d_0++)
     {
       c_q2[i_g][i_d_0] = 0.0;
-      for(int i_r_0 = 0; i_r_0 < 3; i_r_0++)
+      for(int q_r_0 = 0; q_r_0 < 3; q_r_0++)
       {
-        c_q2[i_g][i_d_0] += c2[i_r_0][i_d_0] * CG1[i_r_0][i_g];
+        c_q2[i_g][i_d_0] += c2[q_r_0][i_d_0] * CG1[q_r_0][i_g];
       };
     };
   };
   for(int i_r_0 = 0; i_r_0 < 3; i_r_0++)
   {
-    localTensor[i_r_0] = 0.0;
+    localTensor[i_r_0][0] = 0.0;
     for(int i_g = 0; i_g < 6; i_g++)
     {
       double ST0 = 0.0;
@@ -82,12 +82,12 @@ void rhs(double localTensor[3], double dt, double c0[3][2], double c1[3], double
           ST1 += c_q2[i_g][i_d_0] * (l40[i_d_4][i_d_0] / (c_q0[i_g][0][0] * c_q0[i_g][1][1] + -1 * c_q0[i_g][0][1] * c_q0[i_g][1][0])) * d_CG1[i_r_0][i_g][i_d_4];
         };
       };
-      localTensor[i_r_0] += ST2 * (c_q1[i_g] * dt * ST1 + ST0) * w[i_g];
+      localTensor[i_r_0][0] += ST2 * (c_q1[i_g] * dt * ST1 + ST0) * w[i_g];
     };
   };
 }
 
-void Mass(double localTensor[3][3], double dt, double c0[3][2])
+void Mass(double* localTensor, double dt, double* c0[2], int i_r_0, int i_r_1)
 {
   const double CG1[3][6] = { {  0.09157621, 0.09157621, 0.81684757,
                                0.44594849, 0.44594849, 0.10810302 },
@@ -125,25 +125,18 @@ void Mass(double localTensor[3][3], double dt, double c0[3][2])
       for(int i_d_1 = 0; i_d_1 < 2; i_d_1++)
       {
         c_q0[i_g][i_d_0][i_d_1] = 0.0;
-        for(int i_r_0 = 0; i_r_0 < 3; i_r_0++)
+        for(int q_r_0 = 0; q_r_0 < 3; q_r_0++)
         {
-          c_q0[i_g][i_d_0][i_d_1] += c0[i_r_0][i_d_0] * d_CG1[i_r_0][i_g][i_d_1];
+          c_q0[i_g][i_d_0][i_d_1] += c0[q_r_0][i_d_0] * d_CG1[q_r_0][i_g][i_d_1];
         };
       };
     };
   };
-  for(int i_r_0 = 0; i_r_0 < 3; i_r_0++)
+  for(int i_g = 0; i_g < 6; i_g++)
   {
-    for(int i_r_1 = 0; i_r_1 < 3; i_r_1++)
-    {
-      localTensor[i_r_0][i_r_1] = 0.0;
-      for(int i_g = 0; i_g < 6; i_g++)
-      {
-        double ST3 = 0.0;
-        ST3 += CG1[i_r_0][i_g] * CG1[i_r_1][i_g] * (c_q0[i_g][0][0] * c_q0[i_g][1][1] + -1 * c_q0[i_g][0][1] * c_q0[i_g][1][0]);
-        localTensor[i_r_0][i_r_1] += ST3 * w[i_g];
-      };
-    };
+    double ST3 = 0.0;
+    ST3 += CG1[i_r_0][i_g] * CG1[i_r_1][i_g] * (c_q0[i_g][0][0] * c_q0[i_g][1][1] + -1 * c_q0[i_g][0][1] * c_q0[i_g][1][0]);
+    localTensor[0] += ST3 * w[i_g];
   };
 }
 

--- a/tests/expected/op2/helmholtz/FluidTracer.cpp
+++ b/tests/expected/op2/helmholtz/FluidTracer.cpp
@@ -4,7 +4,7 @@
 
 
 
-void A(double localTensor[3][3], double dt, double c0[3][2])
+void A(double* localTensor, double dt, double* c0[2], int i_r_0, int i_r_1)
 {
   const double CG1[3][6] = { {  0.09157621, 0.09157621, 0.81684757,
                                0.44594849, 0.44594849, 0.10810302 },
@@ -42,44 +42,37 @@ void A(double localTensor[3][3], double dt, double c0[3][2])
       for(int i_d_1 = 0; i_d_1 < 2; i_d_1++)
       {
         c_q0[i_g][i_d_0][i_d_1] = 0.0;
-        for(int i_r_0 = 0; i_r_0 < 3; i_r_0++)
+        for(int q_r_0 = 0; q_r_0 < 3; q_r_0++)
         {
-          c_q0[i_g][i_d_0][i_d_1] += c0[i_r_0][i_d_0] * d_CG1[i_r_0][i_g][i_d_1];
+          c_q0[i_g][i_d_0][i_d_1] += c0[q_r_0][i_d_0] * d_CG1[q_r_0][i_g][i_d_1];
         };
       };
     };
   };
-  for(int i_r_0 = 0; i_r_0 < 3; i_r_0++)
+  for(int i_g = 0; i_g < 6; i_g++)
   {
-    for(int i_r_1 = 0; i_r_1 < 3; i_r_1++)
+    double ST1 = 0.0;
+    double ST0 = 0.0;
+    double ST2 = 0.0;
+    ST1 += -1 * CG1[i_r_0][i_g] * CG1[i_r_1][i_g];
+    double l95[2][2] = { { c_q0[i_g][1][1], -1 * c_q0[i_g][0][1] }, { -1 * c_q0[i_g][1][0], c_q0[i_g][0][0] } };
+    double l35[2][2] = { { c_q0[i_g][1][1], -1 * c_q0[i_g][0][1] }, { -1 * c_q0[i_g][1][0], c_q0[i_g][0][0] } };
+    ST2 += c_q0[i_g][0][0] * c_q0[i_g][1][1] + -1 * c_q0[i_g][0][1] * c_q0[i_g][1][0];
+    for(int i_d_5 = 0; i_d_5 < 2; i_d_5++)
     {
-      localTensor[i_r_0][i_r_1] = 0.0;
-      for(int i_g = 0; i_g < 6; i_g++)
+      for(int i_d_3 = 0; i_d_3 < 2; i_d_3++)
       {
-        double ST1 = 0.0;
-        double ST0 = 0.0;
-        double ST2 = 0.0;
-        ST1 += -1 * CG1[i_r_0][i_g] * CG1[i_r_1][i_g];
-        double l95[2][2] = { { c_q0[i_g][1][1], -1 * c_q0[i_g][0][1] }, { -1 * c_q0[i_g][1][0], c_q0[i_g][0][0] } };
-        double l35[2][2] = { { c_q0[i_g][1][1], -1 * c_q0[i_g][0][1] }, { -1 * c_q0[i_g][1][0], c_q0[i_g][0][0] } };
-        ST2 += c_q0[i_g][0][0] * c_q0[i_g][1][1] + -1 * c_q0[i_g][0][1] * c_q0[i_g][1][0];
-        for(int i_d_5 = 0; i_d_5 < 2; i_d_5++)
+        for(int i_d_9 = 0; i_d_9 < 2; i_d_9++)
         {
-          for(int i_d_3 = 0; i_d_3 < 2; i_d_3++)
-          {
-            for(int i_d_9 = 0; i_d_9 < 2; i_d_9++)
-            {
-              ST0 += (l35[i_d_3][i_d_5] / (c_q0[i_g][0][0] * c_q0[i_g][1][1] + -1 * c_q0[i_g][0][1] * c_q0[i_g][1][0])) * d_CG1[i_r_0][i_g][i_d_3] * (l95[i_d_9][i_d_5] / (c_q0[i_g][0][0] * c_q0[i_g][1][1] + -1 * c_q0[i_g][0][1] * c_q0[i_g][1][0])) * d_CG1[i_r_1][i_g][i_d_9];
-            };
-          };
+          ST0 += (l35[i_d_3][i_d_5] / (c_q0[i_g][0][0] * c_q0[i_g][1][1] + -1 * c_q0[i_g][0][1] * c_q0[i_g][1][0])) * d_CG1[i_r_0][i_g][i_d_3] * (l95[i_d_9][i_d_5] / (c_q0[i_g][0][0] * c_q0[i_g][1][1] + -1 * c_q0[i_g][0][1] * c_q0[i_g][1][0])) * d_CG1[i_r_1][i_g][i_d_9];
         };
-        localTensor[i_r_0][i_r_1] += ST2 * (ST0 + ST1) * w[i_g];
       };
     };
+    localTensor[0] += ST2 * (ST0 + ST1) * w[i_g];
   };
 }
 
-void RHS(double localTensor[3], double dt, double c0[3][2], double c1[3])
+void RHS(double** localTensor, double dt, double* c0[2], double* c1)
 {
   const double CG1[3][6] = { {  0.09157621, 0.09157621, 0.81684757,
                                0.44594849, 0.44594849, 0.10810302 },
@@ -114,30 +107,30 @@ void RHS(double localTensor[3], double dt, double c0[3][2], double c1[3])
   for(int i_g = 0; i_g < 6; i_g++)
   {
     c_q1[i_g] = 0.0;
-    for(int i_r_0 = 0; i_r_0 < 3; i_r_0++)
+    for(int q_r_0 = 0; q_r_0 < 3; q_r_0++)
     {
-      c_q1[i_g] += c1[i_r_0] * CG1[i_r_0][i_g];
+      c_q1[i_g] += c1[q_r_0] * CG1[q_r_0][i_g];
     };
     for(int i_d_0 = 0; i_d_0 < 2; i_d_0++)
     {
       for(int i_d_1 = 0; i_d_1 < 2; i_d_1++)
       {
         c_q0[i_g][i_d_0][i_d_1] = 0.0;
-        for(int i_r_0 = 0; i_r_0 < 3; i_r_0++)
+        for(int q_r_0 = 0; q_r_0 < 3; q_r_0++)
         {
-          c_q0[i_g][i_d_0][i_d_1] += c0[i_r_0][i_d_0] * d_CG1[i_r_0][i_g][i_d_1];
+          c_q0[i_g][i_d_0][i_d_1] += c0[q_r_0][i_d_0] * d_CG1[q_r_0][i_g][i_d_1];
         };
       };
     };
   };
   for(int i_r_0 = 0; i_r_0 < 3; i_r_0++)
   {
-    localTensor[i_r_0] = 0.0;
+    localTensor[i_r_0][0] = 0.0;
     for(int i_g = 0; i_g < 6; i_g++)
     {
       double ST3 = 0.0;
       ST3 += CG1[i_r_0][i_g] * c_q1[i_g] * (c_q0[i_g][0][0] * c_q0[i_g][1][1] + -1 * c_q0[i_g][0][1] * c_q0[i_g][1][0]);
-      localTensor[i_r_0] += ST3 * w[i_g];
+      localTensor[i_r_0][0] += ST3 * w[i_g];
     };
   };
 }

--- a/tests/expected/op2/identity-vector/model.cpp
+++ b/tests/expected/op2/identity-vector/model.cpp
@@ -4,7 +4,7 @@
 
 
 
-void A(double localTensor[6][6], double dt, double c0[3][2])
+void A(double* localTensor, double dt, double* c0[2], int i_r_0, int i_r_1)
 {
   const double CG1[3][6] = { {  0.09157621, 0.09157621, 0.81684757,
                                0.44594849, 0.44594849, 0.10810302 },
@@ -67,34 +67,27 @@ void A(double localTensor[6][6], double dt, double c0[3][2])
       for(int i_d_1 = 0; i_d_1 < 2; i_d_1++)
       {
         c_q0[i_g][i_d_0][i_d_1] = 0.0;
-        for(int i_r_0 = 0; i_r_0 < 3; i_r_0++)
+        for(int q_r_0 = 0; q_r_0 < 3; q_r_0++)
         {
-          c_q0[i_g][i_d_0][i_d_1] += c0[i_r_0][i_d_0] * d_CG1[i_r_0][i_g][i_d_1];
+          c_q0[i_g][i_d_0][i_d_1] += c0[q_r_0][i_d_0] * d_CG1[q_r_0][i_g][i_d_1];
         };
       };
     };
   };
-  for(int i_r_0 = 0; i_r_0 < 6; i_r_0++)
+  for(int i_g = 0; i_g < 6; i_g++)
   {
-    for(int i_r_1 = 0; i_r_1 < 6; i_r_1++)
+    double ST1 = 0.0;
+    double ST0 = 0.0;
+    ST1 += c_q0[i_g][0][0] * c_q0[i_g][1][1] + -1 * c_q0[i_g][0][1] * c_q0[i_g][1][0];
+    for(int i_d_0 = 0; i_d_0 < 2; i_d_0++)
     {
-      localTensor[i_r_0][i_r_1] = 0.0;
-      for(int i_g = 0; i_g < 6; i_g++)
-      {
-        double ST1 = 0.0;
-        double ST0 = 0.0;
-        ST1 += c_q0[i_g][0][0] * c_q0[i_g][1][1] + -1 * c_q0[i_g][0][1] * c_q0[i_g][1][0];
-        for(int i_d_0 = 0; i_d_0 < 2; i_d_0++)
-        {
-          ST0 += CG1_v[i_d_0][i_r_0][i_g] * CG1_v[i_d_0][i_r_1][i_g];
-        };
-        localTensor[i_r_0][i_r_1] += ST0 * ST1 * w[i_g];
-      };
+      ST0 += CG1_v[i_d_0][i_r_0][i_g] * CG1_v[i_d_0][i_r_1][i_g];
     };
+    localTensor[0] += ST0 * ST1 * w[i_g];
   };
 }
 
-void RHS(double localTensor[6], double dt, double c0[3][2], double c1[3][2])
+void RHS(double** localTensor, double dt, double* c0[2], double* c1[2])
 {
   const double CG1[3][6] = { {  0.09157621, 0.09157621, 0.81684757,
                                0.44594849, 0.44594849, 0.10810302 },
@@ -156,9 +149,9 @@ void RHS(double localTensor[6], double dt, double c0[3][2], double c1[3][2])
     for(int i_d_0 = 0; i_d_0 < 2; i_d_0++)
     {
       c_q1[i_g][i_d_0] = 0.0;
-      for(int i_r_0 = 0; i_r_0 < 3; i_r_0++)
+      for(int q_r_0 = 0; q_r_0 < 3; q_r_0++)
       {
-        c_q1[i_g][i_d_0] += c1[i_r_0][i_d_0] * CG1[i_r_0][i_g];
+        c_q1[i_g][i_d_0] += c1[q_r_0][i_d_0] * CG1[q_r_0][i_g];
       };
     };
     for(int i_d_0 = 0; i_d_0 < 2; i_d_0++)
@@ -166,16 +159,16 @@ void RHS(double localTensor[6], double dt, double c0[3][2], double c1[3][2])
       for(int i_d_1 = 0; i_d_1 < 2; i_d_1++)
       {
         c_q0[i_g][i_d_0][i_d_1] = 0.0;
-        for(int i_r_0 = 0; i_r_0 < 3; i_r_0++)
+        for(int q_r_0 = 0; q_r_0 < 3; q_r_0++)
         {
-          c_q0[i_g][i_d_0][i_d_1] += c0[i_r_0][i_d_0] * d_CG1[i_r_0][i_g][i_d_1];
+          c_q0[i_g][i_d_0][i_d_1] += c0[q_r_0][i_d_0] * d_CG1[q_r_0][i_g][i_d_1];
         };
       };
     };
   };
   for(int i_r_0 = 0; i_r_0 < 6; i_r_0++)
   {
-    localTensor[i_r_0] = 0.0;
+    localTensor[i_r_0][0] = 0.0;
     for(int i_g = 0; i_g < 6; i_g++)
     {
       double ST3 = 0.0;
@@ -185,7 +178,7 @@ void RHS(double localTensor[6], double dt, double c0[3][2], double c1[3][2])
       {
         ST2 += CG1_v[i_d_0][i_r_0][i_g] * c_q1[i_g][i_d_0];
       };
-      localTensor[i_r_0] += ST2 * ST3 * w[i_g];
+      localTensor[i_r_0][0] += ST2 * ST3 * w[i_g];
     };
   };
 }

--- a/tests/expected/op2/identity/FluidTracer.cpp
+++ b/tests/expected/op2/identity/FluidTracer.cpp
@@ -4,7 +4,7 @@
 
 
 
-void a(double localTensor[3][3], double dt, double c0[3][2])
+void a(double* localTensor, double dt, double* c0[2], int i, int j)
 {
   const double CG1[3][6] = { {  0.09157621, 0.09157621, 0.81684757,
                                0.44594849, 0.44594849, 0.10810302 },
@@ -49,22 +49,16 @@ void a(double localTensor[3][3], double dt, double c0[3][2])
       };
     };
   };
-  for(int i_r_0 = 0; i_r_0 < 3; i_r_0++)
+  
+  for(int i_g = 0; i_g < 6; i_g++)
   {
-    for(int i_r_1 = 0; i_r_1 < 3; i_r_1++)
-    {
-      localTensor[i_r_0][i_r_1] = 0.0;
-      for(int i_g = 0; i_g < 6; i_g++)
-      {
-        double ST0 = 0.0;
-        ST0 += CG1[i_r_0][i_g] * CG1[i_r_1][i_g] * (c_q0[i_g][0][0] * c_q0[i_g][1][1] + -1 * c_q0[i_g][0][1] * c_q0[i_g][1][0]);
-        localTensor[i_r_0][i_r_1] += ST0 * w[i_g];
-      };
-    };
+    double ST0 = 0.0;
+    ST0 += CG1[i][i_g] * CG1[j][i_g] * (c_q0[i_g][0][0] * c_q0[i_g][1][1] + -1 * c_q0[i_g][0][1] * c_q0[i_g][1][0]);
+    localTensor[i][j] += ST0 * w[i_g];
   };
 }
 
-void L(double localTensor[3], double dt, double c0[3][2], double c1[3])
+void L(double** localTensor, double dt, double* c0[2], double* c1)
 {
   const double CG1[3][6] = { {  0.09157621, 0.09157621, 0.81684757,
                                0.44594849, 0.44594849, 0.10810302 },

--- a/tests/expected/op2/identity/FluidTracer.cpp
+++ b/tests/expected/op2/identity/FluidTracer.cpp
@@ -4,7 +4,7 @@
 
 
 
-void a(double* localTensor, double dt, double* c0[2], int i, int j)
+void a(double* localTensor, double dt, double* c0[2], int i_r_0, int i_r_1)
 {
   const double CG1[3][6] = { {  0.09157621, 0.09157621, 0.81684757,
                                0.44594849, 0.44594849, 0.10810302 },
@@ -42,9 +42,9 @@ void a(double* localTensor, double dt, double* c0[2], int i, int j)
       for(int i_d_1 = 0; i_d_1 < 2; i_d_1++)
       {
         c_q0[i_g][i_d_0][i_d_1] = 0.0;
-        for(int i_r_0 = 0; i_r_0 < 3; i_r_0++)
+        for(int q_r_0 = 0; q_r_0 < 3; q_r_0++)
         {
-          c_q0[i_g][i_d_0][i_d_1] += c0[i_r_0][i_d_0] * d_CG1[i_r_0][i_g][i_d_1];
+          c_q0[i_g][i_d_0][i_d_1] += c0[q_r_0][i_d_0] * d_CG1[q_r_0][i_g][i_d_1];
         };
       };
     };
@@ -52,7 +52,7 @@ void a(double* localTensor, double dt, double* c0[2], int i, int j)
   for(int i_g = 0; i_g < 6; i_g++)
   {
     double ST0 = 0.0;
-    ST0 += CG1[i][i_g] * CG1[j][i_g] * (c_q0[i_g][0][0] * c_q0[i_g][1][1] + -1 * c_q0[i_g][0][1] * c_q0[i_g][1][0]);
+    ST0 += CG1[i_r_0][i_g] * CG1[i_r_1][i_g] * (c_q0[i_g][0][0] * c_q0[i_g][1][1] + -1 * c_q0[i_g][0][1] * c_q0[i_g][1][0]);
     localTensor[0] += ST0 * w[i_g];
   };
 }
@@ -92,18 +92,18 @@ void L(double** localTensor, double dt, double* c0[2], double* c1)
   for(int i_g = 0; i_g < 6; i_g++)
   {
     c_q1[i_g] = 0.0;
-    for(int i_r_0 = 0; i_r_0 < 3; i_r_0++)
+    for(int q_r_0 = 0; q_r_0 < 3; q_r_0++)
     {
-      c_q1[i_g] += c1[i_r_0] * CG1[i_r_0][i_g];
+      c_q1[i_g] += c1[q_r_0] * CG1[q_r_0][i_g];
     };
     for(int i_d_0 = 0; i_d_0 < 2; i_d_0++)
     {
       for(int i_d_1 = 0; i_d_1 < 2; i_d_1++)
       {
         c_q0[i_g][i_d_0][i_d_1] = 0.0;
-        for(int i_r_0 = 0; i_r_0 < 3; i_r_0++)
+        for(int q_r_0 = 0; q_r_0 < 3; q_r_0++)
         {
-          c_q0[i_g][i_d_0][i_d_1] += c0[i_r_0][i_d_0] * d_CG1[i_r_0][i_g][i_d_1];
+          c_q0[i_g][i_d_0][i_d_1] += c0[q_r_0][i_d_0] * d_CG1[q_r_0][i_g][i_d_1];
         };
       };
     };

--- a/tests/expected/op2/identity/FluidTracer.cpp
+++ b/tests/expected/op2/identity/FluidTracer.cpp
@@ -53,7 +53,7 @@ void a(double* localTensor, double dt, double* c0[2], int i, int j)
   {
     double ST0 = 0.0;
     ST0 += CG1[i][i_g] * CG1[j][i_g] * (c_q0[i_g][0][0] * c_q0[i_g][1][1] + -1 * c_q0[i_g][0][1] * c_q0[i_g][1][0]);
-    localTensor[i][j] += ST0 * w[i_g];
+    localTensor[0] += ST0 * w[i_g];
   };
 }
 
@@ -110,12 +110,12 @@ void L(double** localTensor, double dt, double* c0[2], double* c1)
   };
   for(int i_r_0 = 0; i_r_0 < 3; i_r_0++)
   {
-    localTensor[i_r_0] = 0.0;
+    localTensor[i_r_0][0] = 0.0;
     for(int i_g = 0; i_g < 6; i_g++)
     {
       double ST1 = 0.0;
       ST1 += CG1[i_r_0][i_g] * c_q1[i_g] * (c_q0[i_g][0][0] * c_q0[i_g][1][1] + -1 * c_q0[i_g][0][1] * c_q0[i_g][1][0]);
-      localTensor[i_r_0] += ST1 * w[i_g];
+      localTensor[i_r_0][0] += ST1 * w[i_g];
     };
   };
 }

--- a/tests/expected/op2/identity/FluidTracer.cpp
+++ b/tests/expected/op2/identity/FluidTracer.cpp
@@ -49,7 +49,6 @@ void a(double* localTensor, double dt, double* c0[2], int i, int j)
       };
     };
   };
-  
   for(int i_g = 0; i_g < 6; i_g++)
   {
     double ST0 = 0.0;

--- a/tests/expected/op2/laplacian/model.cpp
+++ b/tests/expected/op2/laplacian/model.cpp
@@ -4,7 +4,7 @@
 
 
 
-void A(double localTensor[3][3], double dt, double c0[3][2])
+void A(double* localTensor, double dt, double* c0[2], int i_r_0, int i_r_1)
 {
   const double CG1[3][6] = { {  0.09157621, 0.09157621, 0.81684757,
                                0.44594849, 0.44594849, 0.10810302 },
@@ -42,42 +42,35 @@ void A(double localTensor[3][3], double dt, double c0[3][2])
       for(int i_d_1 = 0; i_d_1 < 2; i_d_1++)
       {
         c_q0[i_g][i_d_0][i_d_1] = 0.0;
-        for(int i_r_0 = 0; i_r_0 < 3; i_r_0++)
+        for(int q_r_0 = 0; q_r_0 < 3; q_r_0++)
         {
-          c_q0[i_g][i_d_0][i_d_1] += c0[i_r_0][i_d_0] * d_CG1[i_r_0][i_g][i_d_1];
+          c_q0[i_g][i_d_0][i_d_1] += c0[q_r_0][i_d_0] * d_CG1[q_r_0][i_g][i_d_1];
         };
       };
     };
   };
-  for(int i_r_0 = 0; i_r_0 < 3; i_r_0++)
+  for(int i_g = 0; i_g < 6; i_g++)
   {
-    for(int i_r_1 = 0; i_r_1 < 3; i_r_1++)
+    double ST1 = 0.0;
+    double ST0 = 0.0;
+    ST1 += c_q0[i_g][0][0] * c_q0[i_g][1][1] + -1 * c_q0[i_g][0][1] * c_q0[i_g][1][0];
+    double l95[2][2] = { { c_q0[i_g][1][1], -1 * c_q0[i_g][0][1] }, { -1 * c_q0[i_g][1][0], c_q0[i_g][0][0] } };
+    double l35[2][2] = { { c_q0[i_g][1][1], -1 * c_q0[i_g][0][1] }, { -1 * c_q0[i_g][1][0], c_q0[i_g][0][0] } };
+    for(int i_d_5 = 0; i_d_5 < 2; i_d_5++)
     {
-      localTensor[i_r_0][i_r_1] = 0.0;
-      for(int i_g = 0; i_g < 6; i_g++)
+      for(int i_d_3 = 0; i_d_3 < 2; i_d_3++)
       {
-        double ST1 = 0.0;
-        double ST0 = 0.0;
-        ST1 += c_q0[i_g][0][0] * c_q0[i_g][1][1] + -1 * c_q0[i_g][0][1] * c_q0[i_g][1][0];
-        double l95[2][2] = { { c_q0[i_g][1][1], -1 * c_q0[i_g][0][1] }, { -1 * c_q0[i_g][1][0], c_q0[i_g][0][0] } };
-        double l35[2][2] = { { c_q0[i_g][1][1], -1 * c_q0[i_g][0][1] }, { -1 * c_q0[i_g][1][0], c_q0[i_g][0][0] } };
-        for(int i_d_5 = 0; i_d_5 < 2; i_d_5++)
+        for(int i_d_9 = 0; i_d_9 < 2; i_d_9++)
         {
-          for(int i_d_3 = 0; i_d_3 < 2; i_d_3++)
-          {
-            for(int i_d_9 = 0; i_d_9 < 2; i_d_9++)
-            {
-              ST0 += (l35[i_d_3][i_d_5] / (c_q0[i_g][0][0] * c_q0[i_g][1][1] + -1 * c_q0[i_g][0][1] * c_q0[i_g][1][0])) * d_CG1[i_r_0][i_g][i_d_3] * (l95[i_d_9][i_d_5] / (c_q0[i_g][0][0] * c_q0[i_g][1][1] + -1 * c_q0[i_g][0][1] * c_q0[i_g][1][0])) * d_CG1[i_r_1][i_g][i_d_9];
-            };
-          };
+          ST0 += (l35[i_d_3][i_d_5] / (c_q0[i_g][0][0] * c_q0[i_g][1][1] + -1 * c_q0[i_g][0][1] * c_q0[i_g][1][0])) * d_CG1[i_r_0][i_g][i_d_3] * (l95[i_d_9][i_d_5] / (c_q0[i_g][0][0] * c_q0[i_g][1][1] + -1 * c_q0[i_g][0][1] * c_q0[i_g][1][0])) * d_CG1[i_r_1][i_g][i_d_9];
         };
-        localTensor[i_r_0][i_r_1] += ST0 * ST1 * w[i_g];
       };
     };
+    localTensor[0] += ST0 * ST1 * w[i_g];
   };
 }
 
-void RHS(double localTensor[3], double dt, double c0[3][2], double c1[3])
+void RHS(double** localTensor, double dt, double* c0[2], double* c1)
 {
   const double CG1[3][6] = { {  0.09157621, 0.09157621, 0.81684757,
                                0.44594849, 0.44594849, 0.10810302 },
@@ -112,30 +105,30 @@ void RHS(double localTensor[3], double dt, double c0[3][2], double c1[3])
   for(int i_g = 0; i_g < 6; i_g++)
   {
     c_q1[i_g] = 0.0;
-    for(int i_r_0 = 0; i_r_0 < 3; i_r_0++)
+    for(int q_r_0 = 0; q_r_0 < 3; q_r_0++)
     {
-      c_q1[i_g] += c1[i_r_0] * CG1[i_r_0][i_g];
+      c_q1[i_g] += c1[q_r_0] * CG1[q_r_0][i_g];
     };
     for(int i_d_0 = 0; i_d_0 < 2; i_d_0++)
     {
       for(int i_d_1 = 0; i_d_1 < 2; i_d_1++)
       {
         c_q0[i_g][i_d_0][i_d_1] = 0.0;
-        for(int i_r_0 = 0; i_r_0 < 3; i_r_0++)
+        for(int q_r_0 = 0; q_r_0 < 3; q_r_0++)
         {
-          c_q0[i_g][i_d_0][i_d_1] += c0[i_r_0][i_d_0] * d_CG1[i_r_0][i_g][i_d_1];
+          c_q0[i_g][i_d_0][i_d_1] += c0[q_r_0][i_d_0] * d_CG1[q_r_0][i_g][i_d_1];
         };
       };
     };
   };
   for(int i_r_0 = 0; i_r_0 < 3; i_r_0++)
   {
-    localTensor[i_r_0] = 0.0;
+    localTensor[i_r_0][0] = 0.0;
     for(int i_g = 0; i_g < 6; i_g++)
     {
       double ST2 = 0.0;
       ST2 += CG1[i_r_0][i_g] * c_q1[i_g] * (c_q0[i_g][0][0] * c_q0[i_g][1][1] + -1 * c_q0[i_g][0][1] * c_q0[i_g][1][0]);
-      localTensor[i_r_0] += ST2 * w[i_g];
+      localTensor[i_r_0][0] += ST2 * w[i_g];
     };
   };
 }

--- a/tests/expected/op2/simple-advection-diffusion/FluidTracer.cpp
+++ b/tests/expected/op2/simple-advection-diffusion/FluidTracer.cpp
@@ -4,7 +4,7 @@
 
 
 
-void A(double localTensor[3][3], double dt, double c0[3][2])
+void A(double* localTensor, double dt, double* c0[2], int i_r_0, int i_r_1)
 {
   const double CG1[3][6] = { {  0.09157621, 0.09157621, 0.81684757,
                                0.44594849, 0.44594849, 0.10810302 },
@@ -42,46 +42,39 @@ void A(double localTensor[3][3], double dt, double c0[3][2])
       for(int i_d_1 = 0; i_d_1 < 2; i_d_1++)
       {
         c_q0[i_g][i_d_0][i_d_1] = 0.0;
-        for(int i_r_0 = 0; i_r_0 < 3; i_r_0++)
+        for(int q_r_0 = 0; q_r_0 < 3; q_r_0++)
         {
-          c_q0[i_g][i_d_0][i_d_1] += c0[i_r_0][i_d_0] * d_CG1[i_r_0][i_g][i_d_1];
+          c_q0[i_g][i_d_0][i_d_1] += c0[q_r_0][i_d_0] * d_CG1[q_r_0][i_g][i_d_1];
         };
       };
     };
   };
-  for(int i_r_0 = 0; i_r_0 < 3; i_r_0++)
+  for(int i_g = 0; i_g < 6; i_g++)
   {
-    for(int i_r_1 = 0; i_r_1 < 3; i_r_1++)
+    double ST3 = 0.0;
+    double ST2 = 0.0;
+    double ST1 = 0.0;
+    double ST0 = 0.0;
+    ST3 += CG1[i_r_0][i_g] * CG1[i_r_1][i_g] * (c_q0[i_g][0][0] * c_q0[i_g][1][1] + -1 * c_q0[i_g][0][1] * c_q0[i_g][1][0]);
+    ST2 += c_q0[i_g][0][0] * c_q0[i_g][1][1] + -1 * c_q0[i_g][0][1] * c_q0[i_g][1][0];
+    ST1 += 0.1 * -1 * dt;
+    double l95[2][2] = { { c_q0[i_g][1][1], -1 * c_q0[i_g][0][1] }, { -1 * c_q0[i_g][1][0], c_q0[i_g][0][0] } };
+    double l35[2][2] = { { c_q0[i_g][1][1], -1 * c_q0[i_g][0][1] }, { -1 * c_q0[i_g][1][0], c_q0[i_g][0][0] } };
+    for(int i_d_5 = 0; i_d_5 < 2; i_d_5++)
     {
-      localTensor[i_r_0][i_r_1] = 0.0;
-      for(int i_g = 0; i_g < 6; i_g++)
+      for(int i_d_3 = 0; i_d_3 < 2; i_d_3++)
       {
-        double ST3 = 0.0;
-        double ST2 = 0.0;
-        double ST1 = 0.0;
-        double ST0 = 0.0;
-        ST3 += CG1[i_r_0][i_g] * CG1[i_r_1][i_g] * (c_q0[i_g][0][0] * c_q0[i_g][1][1] + -1 * c_q0[i_g][0][1] * c_q0[i_g][1][0]);
-        ST2 += c_q0[i_g][0][0] * c_q0[i_g][1][1] + -1 * c_q0[i_g][0][1] * c_q0[i_g][1][0];
-        ST1 += 0.1 * -1 * dt;
-        double l95[2][2] = { { c_q0[i_g][1][1], -1 * c_q0[i_g][0][1] }, { -1 * c_q0[i_g][1][0], c_q0[i_g][0][0] } };
-        double l35[2][2] = { { c_q0[i_g][1][1], -1 * c_q0[i_g][0][1] }, { -1 * c_q0[i_g][1][0], c_q0[i_g][0][0] } };
-        for(int i_d_5 = 0; i_d_5 < 2; i_d_5++)
+        for(int i_d_9 = 0; i_d_9 < 2; i_d_9++)
         {
-          for(int i_d_3 = 0; i_d_3 < 2; i_d_3++)
-          {
-            for(int i_d_9 = 0; i_d_9 < 2; i_d_9++)
-            {
-              ST0 += (l35[i_d_3][i_d_5] / (c_q0[i_g][0][0] * c_q0[i_g][1][1] + -1 * c_q0[i_g][0][1] * c_q0[i_g][1][0])) * d_CG1[i_r_0][i_g][i_d_3] * (l95[i_d_9][i_d_5] / (c_q0[i_g][0][0] * c_q0[i_g][1][1] + -1 * c_q0[i_g][0][1] * c_q0[i_g][1][0])) * d_CG1[i_r_1][i_g][i_d_9];
-            };
-          };
+          ST0 += (l35[i_d_3][i_d_5] / (c_q0[i_g][0][0] * c_q0[i_g][1][1] + -1 * c_q0[i_g][0][1] * c_q0[i_g][1][0])) * d_CG1[i_r_0][i_g][i_d_3] * (l95[i_d_9][i_d_5] / (c_q0[i_g][0][0] * c_q0[i_g][1][1] + -1 * c_q0[i_g][0][1] * c_q0[i_g][1][0])) * d_CG1[i_r_1][i_g][i_d_9];
         };
-        localTensor[i_r_0][i_r_1] += (-1 * 0.5 * ST0 * ST1 * ST2 + ST3) * w[i_g];
       };
     };
+    localTensor[0] += (-1 * 0.5 * ST0 * ST1 * ST2 + ST3) * w[i_g];
   };
 }
 
-void d(double localTensor[3][3], double dt, double c0[3][2])
+void d(double* localTensor, double dt, double* c0[2], int i_r_0, int i_r_1)
 {
   const double CG1[3][6] = { {  0.09157621, 0.09157621, 0.81684757,
                                0.44594849, 0.44594849, 0.10810302 },
@@ -119,44 +112,37 @@ void d(double localTensor[3][3], double dt, double c0[3][2])
       for(int i_d_1 = 0; i_d_1 < 2; i_d_1++)
       {
         c_q0[i_g][i_d_0][i_d_1] = 0.0;
-        for(int i_r_0 = 0; i_r_0 < 3; i_r_0++)
+        for(int q_r_0 = 0; q_r_0 < 3; q_r_0++)
         {
-          c_q0[i_g][i_d_0][i_d_1] += c0[i_r_0][i_d_0] * d_CG1[i_r_0][i_g][i_d_1];
+          c_q0[i_g][i_d_0][i_d_1] += c0[q_r_0][i_d_0] * d_CG1[q_r_0][i_g][i_d_1];
         };
       };
     };
   };
-  for(int i_r_0 = 0; i_r_0 < 3; i_r_0++)
+  for(int i_g = 0; i_g < 6; i_g++)
   {
-    for(int i_r_1 = 0; i_r_1 < 3; i_r_1++)
+    double ST14 = 0.0;
+    double ST13 = 0.0;
+    double ST12 = 0.0;
+    ST14 += c_q0[i_g][0][0] * c_q0[i_g][1][1] + -1 * c_q0[i_g][0][1] * c_q0[i_g][1][0];
+    ST13 += 0.1 * -1 * dt;
+    double l95[2][2] = { { c_q0[i_g][1][1], -1 * c_q0[i_g][0][1] }, { -1 * c_q0[i_g][1][0], c_q0[i_g][0][0] } };
+    double l35[2][2] = { { c_q0[i_g][1][1], -1 * c_q0[i_g][0][1] }, { -1 * c_q0[i_g][1][0], c_q0[i_g][0][0] } };
+    for(int i_d_5 = 0; i_d_5 < 2; i_d_5++)
     {
-      localTensor[i_r_0][i_r_1] = 0.0;
-      for(int i_g = 0; i_g < 6; i_g++)
+      for(int i_d_3 = 0; i_d_3 < 2; i_d_3++)
       {
-        double ST14 = 0.0;
-        double ST13 = 0.0;
-        double ST12 = 0.0;
-        ST14 += c_q0[i_g][0][0] * c_q0[i_g][1][1] + -1 * c_q0[i_g][0][1] * c_q0[i_g][1][0];
-        ST13 += 0.1 * -1 * dt;
-        double l95[2][2] = { { c_q0[i_g][1][1], -1 * c_q0[i_g][0][1] }, { -1 * c_q0[i_g][1][0], c_q0[i_g][0][0] } };
-        double l35[2][2] = { { c_q0[i_g][1][1], -1 * c_q0[i_g][0][1] }, { -1 * c_q0[i_g][1][0], c_q0[i_g][0][0] } };
-        for(int i_d_5 = 0; i_d_5 < 2; i_d_5++)
+        for(int i_d_9 = 0; i_d_9 < 2; i_d_9++)
         {
-          for(int i_d_3 = 0; i_d_3 < 2; i_d_3++)
-          {
-            for(int i_d_9 = 0; i_d_9 < 2; i_d_9++)
-            {
-              ST12 += (l35[i_d_3][i_d_5] / (c_q0[i_g][0][0] * c_q0[i_g][1][1] + -1 * c_q0[i_g][0][1] * c_q0[i_g][1][0])) * d_CG1[i_r_0][i_g][i_d_3] * (l95[i_d_9][i_d_5] / (c_q0[i_g][0][0] * c_q0[i_g][1][1] + -1 * c_q0[i_g][0][1] * c_q0[i_g][1][0])) * d_CG1[i_r_1][i_g][i_d_9];
-            };
-          };
+          ST12 += (l35[i_d_3][i_d_5] / (c_q0[i_g][0][0] * c_q0[i_g][1][1] + -1 * c_q0[i_g][0][1] * c_q0[i_g][1][0])) * d_CG1[i_r_0][i_g][i_d_3] * (l95[i_d_9][i_d_5] / (c_q0[i_g][0][0] * c_q0[i_g][1][1] + -1 * c_q0[i_g][0][1] * c_q0[i_g][1][0])) * d_CG1[i_r_1][i_g][i_d_9];
         };
-        localTensor[i_r_0][i_r_1] += ST12 * ST13 * ST14 * w[i_g];
       };
     };
+    localTensor[0] += ST12 * ST13 * ST14 * w[i_g];
   };
 }
 
-void M(double localTensor[3][3], double dt, double c0[3][2])
+void M(double* localTensor, double dt, double* c0[2], int i_r_0, int i_r_1)
 {
   const double CG1[3][6] = { {  0.09157621, 0.09157621, 0.81684757,
                                0.44594849, 0.44594849, 0.10810302 },
@@ -194,29 +180,22 @@ void M(double localTensor[3][3], double dt, double c0[3][2])
       for(int i_d_1 = 0; i_d_1 < 2; i_d_1++)
       {
         c_q0[i_g][i_d_0][i_d_1] = 0.0;
-        for(int i_r_0 = 0; i_r_0 < 3; i_r_0++)
+        for(int q_r_0 = 0; q_r_0 < 3; q_r_0++)
         {
-          c_q0[i_g][i_d_0][i_d_1] += c0[i_r_0][i_d_0] * d_CG1[i_r_0][i_g][i_d_1];
+          c_q0[i_g][i_d_0][i_d_1] += c0[q_r_0][i_d_0] * d_CG1[q_r_0][i_g][i_d_1];
         };
       };
     };
   };
-  for(int i_r_0 = 0; i_r_0 < 3; i_r_0++)
+  for(int i_g = 0; i_g < 6; i_g++)
   {
-    for(int i_r_1 = 0; i_r_1 < 3; i_r_1++)
-    {
-      localTensor[i_r_0][i_r_1] = 0.0;
-      for(int i_g = 0; i_g < 6; i_g++)
-      {
-        double ST11 = 0.0;
-        ST11 += CG1[i_r_0][i_g] * CG1[i_r_1][i_g] * (c_q0[i_g][0][0] * c_q0[i_g][1][1] + -1 * c_q0[i_g][0][1] * c_q0[i_g][1][0]);
-        localTensor[i_r_0][i_r_1] += ST11 * w[i_g];
-      };
-    };
+    double ST11 = 0.0;
+    ST11 += CG1[i_r_0][i_g] * CG1[i_r_1][i_g] * (c_q0[i_g][0][0] * c_q0[i_g][1][1] + -1 * c_q0[i_g][0][1] * c_q0[i_g][1][0]);
+    localTensor[0] += ST11 * w[i_g];
   };
 }
 
-void diff_rhs(double localTensor[3], double dt, double c0[3][2], double c1[3])
+void diff_rhs(double** localTensor, double dt, double* c0[2], double* c1)
 {
   const double CG1[3][6] = { {  0.09157621, 0.09157621, 0.81684757,
                                0.44594849, 0.44594849, 0.10810302 },
@@ -256,29 +235,29 @@ void diff_rhs(double localTensor[3], double dt, double c0[3][2], double c1[3])
       for(int i_d_1 = 0; i_d_1 < 2; i_d_1++)
       {
         c_q0[i_g][i_d_0][i_d_1] = 0.0;
-        for(int i_r_0 = 0; i_r_0 < 3; i_r_0++)
+        for(int q_r_0 = 0; q_r_0 < 3; q_r_0++)
         {
-          c_q0[i_g][i_d_0][i_d_1] += c0[i_r_0][i_d_0] * d_CG1[i_r_0][i_g][i_d_1];
+          c_q0[i_g][i_d_0][i_d_1] += c0[q_r_0][i_d_0] * d_CG1[q_r_0][i_g][i_d_1];
         };
       };
     };
     c_q1[i_g] = 0.0;
-    for(int i_r_0 = 0; i_r_0 < 3; i_r_0++)
+    for(int q_r_0 = 0; q_r_0 < 3; q_r_0++)
     {
-      c_q1[i_g] += c1[i_r_0] * CG1[i_r_0][i_g];
+      c_q1[i_g] += c1[q_r_0] * CG1[q_r_0][i_g];
     };
     for(int i_d_0 = 0; i_d_0 < 2; i_d_0++)
     {
       d_c_q1[i_g][i_d_0] = 0.0;
-      for(int i_r_0 = 0; i_r_0 < 3; i_r_0++)
+      for(int q_r_0 = 0; q_r_0 < 3; q_r_0++)
       {
-        d_c_q1[i_g][i_d_0] += c1[i_r_0] * d_CG1[i_r_0][i_g][i_d_0];
+        d_c_q1[i_g][i_d_0] += c1[q_r_0] * d_CG1[q_r_0][i_g][i_d_0];
       };
     };
   };
   for(int i_r_0 = 0; i_r_0 < 3; i_r_0++)
   {
-    localTensor[i_r_0] = 0.0;
+    localTensor[i_r_0][0] = 0.0;
     for(int i_g = 0; i_g < 6; i_g++)
     {
       double ST7 = 0.0;
@@ -300,12 +279,12 @@ void diff_rhs(double localTensor[3], double dt, double c0[3][2], double c1[3])
           };
         };
       };
-      localTensor[i_r_0] += (0.5 * ST4 * ST5 * ST6 + ST7) * w[i_g];
+      localTensor[i_r_0][0] += (0.5 * ST4 * ST5 * ST6 + ST7) * w[i_g];
     };
   };
 }
 
-void adv_rhs(double localTensor[3], double dt, double c0[3][2], double c1[3][2], double c2[3])
+void adv_rhs(double** localTensor, double dt, double* c0[2], double* c1[2], double* c2)
 {
   const double CG1[3][6] = { {  0.09157621, 0.09157621, 0.81684757,
                                0.44594849, 0.44594849, 0.10810302 },
@@ -345,29 +324,29 @@ void adv_rhs(double localTensor[3], double dt, double c0[3][2], double c1[3][2],
       for(int i_d_1 = 0; i_d_1 < 2; i_d_1++)
       {
         c_q0[i_g][i_d_0][i_d_1] = 0.0;
-        for(int i_r_0 = 0; i_r_0 < 3; i_r_0++)
+        for(int q_r_0 = 0; q_r_0 < 3; q_r_0++)
         {
-          c_q0[i_g][i_d_0][i_d_1] += c0[i_r_0][i_d_0] * d_CG1[i_r_0][i_g][i_d_1];
+          c_q0[i_g][i_d_0][i_d_1] += c0[q_r_0][i_d_0] * d_CG1[q_r_0][i_g][i_d_1];
         };
       };
     };
     c_q2[i_g] = 0.0;
-    for(int i_r_0 = 0; i_r_0 < 3; i_r_0++)
+    for(int q_r_0 = 0; q_r_0 < 3; q_r_0++)
     {
-      c_q2[i_g] += c2[i_r_0] * CG1[i_r_0][i_g];
+      c_q2[i_g] += c2[q_r_0] * CG1[q_r_0][i_g];
     };
     for(int i_d_0 = 0; i_d_0 < 2; i_d_0++)
     {
       c_q1[i_g][i_d_0] = 0.0;
-      for(int i_r_0 = 0; i_r_0 < 3; i_r_0++)
+      for(int q_r_0 = 0; q_r_0 < 3; q_r_0++)
       {
-        c_q1[i_g][i_d_0] += c1[i_r_0][i_d_0] * CG1[i_r_0][i_g];
+        c_q1[i_g][i_d_0] += c1[q_r_0][i_d_0] * CG1[q_r_0][i_g];
       };
     };
   };
   for(int i_r_0 = 0; i_r_0 < 3; i_r_0++)
   {
-    localTensor[i_r_0] = 0.0;
+    localTensor[i_r_0][0] = 0.0;
     for(int i_g = 0; i_g < 6; i_g++)
     {
       double ST8 = 0.0;
@@ -383,7 +362,7 @@ void adv_rhs(double localTensor[3], double dt, double c0[3][2], double c1[3][2],
           ST9 += c_q1[i_g][i_d_0] * (l40[i_d_4][i_d_0] / (c_q0[i_g][0][0] * c_q0[i_g][1][1] + -1 * c_q0[i_g][0][1] * c_q0[i_g][1][0])) * d_CG1[i_r_0][i_g][i_d_4];
         };
       };
-      localTensor[i_r_0] += ST10 * (c_q2[i_g] * dt * ST9 + ST8) * w[i_g];
+      localTensor[i_r_0][0] += ST10 * (c_q2[i_g] * dt * ST9 + ST8) * w[i_g];
     };
   };
 }

--- a/tests/expected/op2/swapped-advection/model.cpp
+++ b/tests/expected/op2/swapped-advection/model.cpp
@@ -4,7 +4,7 @@
 
 
 
-void rhs(double localTensor[3], double dt, double c0[3][2], double c1[3], double c2[3][2])
+void rhs(double** localTensor, double dt, double* c0[2], double* c1, double* c2[2])
 {
   const double CG1[3][6] = { {  0.09157621, 0.09157621, 0.81684757,
                                0.44594849, 0.44594849, 0.10810302 },
@@ -44,29 +44,29 @@ void rhs(double localTensor[3], double dt, double c0[3][2], double c1[3], double
       for(int i_d_1 = 0; i_d_1 < 2; i_d_1++)
       {
         c_q0[i_g][i_d_0][i_d_1] = 0.0;
-        for(int i_r_0 = 0; i_r_0 < 3; i_r_0++)
+        for(int q_r_0 = 0; q_r_0 < 3; q_r_0++)
         {
-          c_q0[i_g][i_d_0][i_d_1] += c0[i_r_0][i_d_0] * d_CG1[i_r_0][i_g][i_d_1];
+          c_q0[i_g][i_d_0][i_d_1] += c0[q_r_0][i_d_0] * d_CG1[q_r_0][i_g][i_d_1];
         };
       };
     };
     c_q1[i_g] = 0.0;
-    for(int i_r_0 = 0; i_r_0 < 3; i_r_0++)
+    for(int q_r_0 = 0; q_r_0 < 3; q_r_0++)
     {
-      c_q1[i_g] += c1[i_r_0] * CG1[i_r_0][i_g];
+      c_q1[i_g] += c1[q_r_0] * CG1[q_r_0][i_g];
     };
     for(int i_d_0 = 0; i_d_0 < 2; i_d_0++)
     {
       c_q2[i_g][i_d_0] = 0.0;
-      for(int i_r_0 = 0; i_r_0 < 3; i_r_0++)
+      for(int q_r_0 = 0; q_r_0 < 3; q_r_0++)
       {
-        c_q2[i_g][i_d_0] += c2[i_r_0][i_d_0] * CG1[i_r_0][i_g];
+        c_q2[i_g][i_d_0] += c2[q_r_0][i_d_0] * CG1[q_r_0][i_g];
       };
     };
   };
   for(int i_r_0 = 0; i_r_0 < 3; i_r_0++)
   {
-    localTensor[i_r_0] = 0.0;
+    localTensor[i_r_0][0] = 0.0;
     for(int i_g = 0; i_g < 6; i_g++)
     {
       double ST0 = 0.0;
@@ -83,12 +83,12 @@ void rhs(double localTensor[3], double dt, double c0[3][2], double c1[3], double
           ST1 += (l35[i_d_3][i_d_5] / (c_q0[i_g][0][0] * c_q0[i_g][1][1] + -1 * c_q0[i_g][0][1] * c_q0[i_g][1][0])) * d_CG1[i_r_0][i_g][i_d_3] * l5[i_d_5];
         };
       };
-      localTensor[i_r_0] += ST2 * (c_q1[i_g] * dt * ST1 + ST0) * w[i_g];
+      localTensor[i_r_0][0] += ST2 * (c_q1[i_g] * dt * ST1 + ST0) * w[i_g];
     };
   };
 }
 
-void Mass(double localTensor[3][3], double dt, double c0[3][2])
+void Mass(double* localTensor, double dt, double* c0[2], int i_r_0, int i_r_1)
 {
   const double CG1[3][6] = { {  0.09157621, 0.09157621, 0.81684757,
                                0.44594849, 0.44594849, 0.10810302 },
@@ -126,25 +126,18 @@ void Mass(double localTensor[3][3], double dt, double c0[3][2])
       for(int i_d_1 = 0; i_d_1 < 2; i_d_1++)
       {
         c_q0[i_g][i_d_0][i_d_1] = 0.0;
-        for(int i_r_0 = 0; i_r_0 < 3; i_r_0++)
+        for(int q_r_0 = 0; q_r_0 < 3; q_r_0++)
         {
-          c_q0[i_g][i_d_0][i_d_1] += c0[i_r_0][i_d_0] * d_CG1[i_r_0][i_g][i_d_1];
+          c_q0[i_g][i_d_0][i_d_1] += c0[q_r_0][i_d_0] * d_CG1[q_r_0][i_g][i_d_1];
         };
       };
     };
   };
-  for(int i_r_0 = 0; i_r_0 < 3; i_r_0++)
+  for(int i_g = 0; i_g < 6; i_g++)
   {
-    for(int i_r_1 = 0; i_r_1 < 3; i_r_1++)
-    {
-      localTensor[i_r_0][i_r_1] = 0.0;
-      for(int i_g = 0; i_g < 6; i_g++)
-      {
-        double ST3 = 0.0;
-        ST3 += CG1[i_r_0][i_g] * CG1[i_r_1][i_g] * (c_q0[i_g][0][0] * c_q0[i_g][1][1] + -1 * c_q0[i_g][0][1] * c_q0[i_g][1][0]);
-        localTensor[i_r_0][i_r_1] += ST3 * w[i_g];
-      };
-    };
+    double ST3 = 0.0;
+    ST3 += CG1[i_r_0][i_g] * CG1[i_r_1][i_g] * (c_q0[i_g][0][0] * c_q0[i_g][1][1] + -1 * c_q0[i_g][0][1] * c_q0[i_g][1][0]);
+    localTensor[0] += ST3 * w[i_g];
   };
 }
 


### PR DESCRIPTION
Summary of the changes:
- OP2 Matrix assembly kernels don't contain loops over the basis functions anymore - instead, the basis function indices are passed as parameters after all the other parameters.
- OP2 Matrix assembly kernels don't contain statements to zero the local tensor.
- The loops over basis functions in the quadrature loop have been renamed. Instead of calling these indices `i_r_*`, they are now called `q_r_*` - this is because the scope of the basis function indices in the OP2
  matrix assembly kernels is now the entire kernel, rather than being constrained to loops inside the kernel. Although the scoping rules would always have allowed the correct index value to be used, it seemed confusing to have the same index name in two scopes that were nested. The quadrature loop basis indices are represented by the QuadratureBasisIndex class.
- Expected outputs updated to match the new code generation.
- Minor changes in the code generation backend to save generating expressions like `;` when NullExpressions are part of the AST, a bugfix when unparsing pointers to arrays, and better feedback in the (now unused) `getScopeFromNest()` function. Note that NullExpressions aren't actually inserted into the AST in this merge, although this was true at one point in some of the earlier commits to this branch.

These tests have passed on the devtests-grm08 queues on the buildbot. Additionally, I tried substituting
the mass kernel generated by MCFC into the mass2d example from Lawrence's OP2-Common repository. When com
piled against the sequential library, and executed with `$ ./mass2d_seq -mat_view`, the matrix produced i
s plausibly similar to the one produced by the original mass2d example, although there seems to be a diff
erence in the numbering of DOFs between Fluidity and the mass2d example. See:

https://github.com/gmarkall/OP2-Common/blob/f6422a0ff6953f4d4f7a570b245270122f59d975/apps/c/mass2d/mass.h

for the example that I tested with.
