### PR TITLE
Fix op2 rhs assembly

### DIFF
--- a/mcfc/op2expression.py
+++ b/mcfc/op2expression.py
@@ -58,6 +58,12 @@ class Op2QuadratureExpressionBuilder(QuadratureExpressionBuilder):
         # dimension(s) (same for tensor-valued coefficients). Hence we need to
         # extract the scalar element to build the appropriate basis index.
         indices = [buildQuadratureBasisIndex(0, extract_subelement(tree))]
+        
+        # Scalars are actually an array of length 1
+        if tree.rank() == 0:
+            indices.append(buildConstDimIndex(0))
+        
+        # This deals with the general case (vectors, tensors)
         for r in range(tree.rank()):
             indices.append(buildDimIndex(r,tree))
         return indices

--- a/mcfc/op2form.py
+++ b/mcfc/op2form.py
@@ -55,6 +55,9 @@ class Op2FormBackend(FormBackend):
         else:
             return super(Op2FormBackend, self).buildLocalTensorLoops(form, gaussLoop)
 
+    def buildLocalTensorInitialiser(self, form):
+        return NullExpression()
+
     def _buildKernelParameters(self, form):
         p = super(Op2FormBackend, self)._buildKernelParameters(form)
         # For a local matrix, we need parameters for the op2 iteration space

--- a/tests/expected/op2/diffusion-1/model.cpp
+++ b/tests/expected/op2/diffusion-1/model.cpp
@@ -233,7 +233,7 @@ void M(double* localTensor, double dt, double* c0[2], int i_r_0, int i_r_1)
   };
 }
 
-void rhs(double** localTensor, double dt, double* c0[2], double* c1, double* c2[2][2])
+void rhs(double** localTensor, double dt, double* c0[2], double* c1[1], double* c2[2][2])
 {
   const double CG1[3][6] = { {  0.0915762135097707, 0.0915762135097707,
                                0.8168475729804585, 0.4459484909159649,
@@ -298,14 +298,14 @@ void rhs(double** localTensor, double dt, double* c0[2], double* c1, double* c2[
     c_q1[i_g] = 0.0;
     for(int q_r_0 = 0; q_r_0 < 3; q_r_0++)
     {
-      c_q1[i_g] += c1[q_r_0] * CG1[q_r_0][i_g];
+      c_q1[i_g] += c1[q_r_0][0] * CG1[q_r_0][i_g];
     };
     for(int i_d_0 = 0; i_d_0 < 2; i_d_0++)
     {
       d_c_q1[i_g][i_d_0] = 0.0;
       for(int q_r_0 = 0; q_r_0 < 3; q_r_0++)
       {
-        d_c_q1[i_g][i_d_0] += c1[q_r_0] * d_CG1[q_r_0][i_g][i_d_0];
+        d_c_q1[i_g][i_d_0] += c1[q_r_0][0] * d_CG1[q_r_0][i_g][i_d_0];
       };
     };
   };

--- a/tests/expected/op2/diffusion-1/model.cpp
+++ b/tests/expected/op2/diffusion-1/model.cpp
@@ -311,7 +311,6 @@ void rhs(double** localTensor, double dt, double* c0[2], double* c1, double* c2[
   };
   for(int i_r_0 = 0; i_r_0 < 3; i_r_0++)
   {
-    localTensor[i_r_0][0] = 0.0;
     for(int i_g = 0; i_g < 6; i_g++)
     {
       double ST5 = 0.0;

--- a/tests/expected/op2/diffusion-2/model.cpp
+++ b/tests/expected/op2/diffusion-2/model.cpp
@@ -233,7 +233,7 @@ void M(double* localTensor, double dt, double* c0[2], int i_r_0, int i_r_1)
   };
 }
 
-void rhs(double** localTensor, double dt, double* c0[2], double* c1, double* c2[2][2])
+void rhs(double** localTensor, double dt, double* c0[2], double* c1[1], double* c2[2][2])
 {
   const double CG1[3][6] = { {  0.0915762135097707, 0.0915762135097707,
                                0.8168475729804585, 0.4459484909159649,
@@ -298,14 +298,14 @@ void rhs(double** localTensor, double dt, double* c0[2], double* c1, double* c2[
     c_q1[i_g] = 0.0;
     for(int q_r_0 = 0; q_r_0 < 3; q_r_0++)
     {
-      c_q1[i_g] += c1[q_r_0] * CG1[q_r_0][i_g];
+      c_q1[i_g] += c1[q_r_0][0] * CG1[q_r_0][i_g];
     };
     for(int i_d_0 = 0; i_d_0 < 2; i_d_0++)
     {
       d_c_q1[i_g][i_d_0] = 0.0;
       for(int q_r_0 = 0; q_r_0 < 3; q_r_0++)
       {
-        d_c_q1[i_g][i_d_0] += c1[q_r_0] * d_CG1[q_r_0][i_g][i_d_0];
+        d_c_q1[i_g][i_d_0] += c1[q_r_0][0] * d_CG1[q_r_0][i_g][i_d_0];
       };
     };
   };

--- a/tests/expected/op2/diffusion-2/model.cpp
+++ b/tests/expected/op2/diffusion-2/model.cpp
@@ -311,7 +311,6 @@ void rhs(double** localTensor, double dt, double* c0[2], double* c1, double* c2[
   };
   for(int i_r_0 = 0; i_r_0 < 3; i_r_0++)
   {
-    localTensor[i_r_0][0] = 0.0;
     for(int i_g = 0; i_g < 6; i_g++)
     {
       double ST5 = 0.0;

--- a/tests/expected/op2/diffusion-3/FluidTracer.cpp
+++ b/tests/expected/op2/diffusion-3/FluidTracer.cpp
@@ -273,7 +273,6 @@ void rhs(double** localTensor, double dt, double* c0[2], double* c1)
   };
   for(int i_r_0 = 0; i_r_0 < 3; i_r_0++)
   {
-    localTensor[i_r_0][0] = 0.0;
     for(int i_g = 0; i_g < 6; i_g++)
     {
       double ST7 = 0.0;

--- a/tests/expected/op2/diffusion-3/FluidTracer.cpp
+++ b/tests/expected/op2/diffusion-3/FluidTracer.cpp
@@ -207,7 +207,7 @@ void M(double* localTensor, double dt, double* c0[2], int i_r_0, int i_r_1)
   };
 }
 
-void rhs(double** localTensor, double dt, double* c0[2], double* c1)
+void rhs(double** localTensor, double dt, double* c0[2], double* c1[1])
 {
   const double CG1[3][6] = { {  0.0915762135097707, 0.0915762135097707,
                                0.8168475729804585, 0.4459484909159649,
@@ -260,14 +260,14 @@ void rhs(double** localTensor, double dt, double* c0[2], double* c1)
     c_q1[i_g] = 0.0;
     for(int q_r_0 = 0; q_r_0 < 3; q_r_0++)
     {
-      c_q1[i_g] += c1[q_r_0] * CG1[q_r_0][i_g];
+      c_q1[i_g] += c1[q_r_0][0] * CG1[q_r_0][i_g];
     };
     for(int i_d_0 = 0; i_d_0 < 2; i_d_0++)
     {
       d_c_q1[i_g][i_d_0] = 0.0;
       for(int q_r_0 = 0; q_r_0 < 3; q_r_0++)
       {
-        d_c_q1[i_g][i_d_0] += c1[q_r_0] * d_CG1[q_r_0][i_g][i_d_0];
+        d_c_q1[i_g][i_d_0] += c1[q_r_0][0] * d_CG1[q_r_0][i_g][i_d_0];
       };
     };
   };

--- a/tests/expected/op2/euler-advection/FluidTracer.cpp
+++ b/tests/expected/op2/euler-advection/FluidTracer.cpp
@@ -4,7 +4,7 @@
 
 
 
-void rhs(double** localTensor, double dt, double* c0[2], double* c1, double* c2[2])
+void rhs(double** localTensor, double dt, double* c0[2], double* c1[1], double* c2[2])
 {
   const double CG1[3][6] = { {  0.0915762135097707, 0.0915762135097707,
                                0.8168475729804585, 0.4459484909159649,
@@ -57,7 +57,7 @@ void rhs(double** localTensor, double dt, double* c0[2], double* c1, double* c2[
     c_q1[i_g] = 0.0;
     for(int q_r_0 = 0; q_r_0 < 3; q_r_0++)
     {
-      c_q1[i_g] += c1[q_r_0] * CG1[q_r_0][i_g];
+      c_q1[i_g] += c1[q_r_0][0] * CG1[q_r_0][i_g];
     };
     for(int i_d_0 = 0; i_d_0 < 2; i_d_0++)
     {

--- a/tests/expected/op2/euler-advection/FluidTracer.cpp
+++ b/tests/expected/op2/euler-advection/FluidTracer.cpp
@@ -70,7 +70,6 @@ void rhs(double** localTensor, double dt, double* c0[2], double* c1, double* c2[
   };
   for(int i_r_0 = 0; i_r_0 < 3; i_r_0++)
   {
-    localTensor[i_r_0][0] = 0.0;
     for(int i_g = 0; i_g < 6; i_g++)
     {
       double ST0 = 0.0;

--- a/tests/expected/op2/helmholtz/FluidTracer.cpp
+++ b/tests/expected/op2/helmholtz/FluidTracer.cpp
@@ -76,7 +76,7 @@ void A(double* localTensor, double dt, double* c0[2], int i_r_0, int i_r_1)
   };
 }
 
-void RHS(double** localTensor, double dt, double* c0[2], double* c1)
+void RHS(double** localTensor, double dt, double* c0[2], double* c1[1])
 {
   const double CG1[3][6] = { {  0.0915762135097707, 0.0915762135097707,
                                0.8168475729804585, 0.4459484909159649,
@@ -117,7 +117,7 @@ void RHS(double** localTensor, double dt, double* c0[2], double* c1)
     c_q1[i_g] = 0.0;
     for(int q_r_0 = 0; q_r_0 < 3; q_r_0++)
     {
-      c_q1[i_g] += c1[q_r_0] * CG1[q_r_0][i_g];
+      c_q1[i_g] += c1[q_r_0][0] * CG1[q_r_0][i_g];
     };
     for(int i_d_0 = 0; i_d_0 < 2; i_d_0++)
     {

--- a/tests/expected/op2/helmholtz/FluidTracer.cpp
+++ b/tests/expected/op2/helmholtz/FluidTracer.cpp
@@ -133,7 +133,6 @@ void RHS(double** localTensor, double dt, double* c0[2], double* c1)
   };
   for(int i_r_0 = 0; i_r_0 < 3; i_r_0++)
   {
-    localTensor[i_r_0][0] = 0.0;
     for(int i_g = 0; i_g < 6; i_g++)
     {
       double ST3 = 0.0;

--- a/tests/expected/op2/identity-vector/model.cpp
+++ b/tests/expected/op2/identity-vector/model.cpp
@@ -260,7 +260,6 @@ void RHS(double** localTensor, double dt, double* c0[2], double* c1[2])
   };
   for(int i_r_0 = 0; i_r_0 < 6; i_r_0++)
   {
-    localTensor[i_r_0][0] = 0.0;
     for(int i_g = 0; i_g < 6; i_g++)
     {
       double ST3 = 0.0;

--- a/tests/expected/op2/identity/FluidTracer.cpp
+++ b/tests/expected/op2/identity/FluidTracer.cpp
@@ -61,7 +61,7 @@ void a(double* localTensor, double dt, double* c0[2], int i_r_0, int i_r_1)
   };
 }
 
-void L(double** localTensor, double dt, double* c0[2], double* c1)
+void L(double** localTensor, double dt, double* c0[2], double* c1[1])
 {
   const double CG1[3][6] = { {  0.0915762135097707, 0.0915762135097707,
                                0.8168475729804585, 0.4459484909159649,
@@ -102,7 +102,7 @@ void L(double** localTensor, double dt, double* c0[2], double* c1)
     c_q1[i_g] = 0.0;
     for(int q_r_0 = 0; q_r_0 < 3; q_r_0++)
     {
-      c_q1[i_g] += c1[q_r_0] * CG1[q_r_0][i_g];
+      c_q1[i_g] += c1[q_r_0][0] * CG1[q_r_0][i_g];
     };
     for(int i_d_0 = 0; i_d_0 < 2; i_d_0++)
     {

--- a/tests/expected/op2/identity/FluidTracer.cpp
+++ b/tests/expected/op2/identity/FluidTracer.cpp
@@ -118,7 +118,6 @@ void L(double** localTensor, double dt, double* c0[2], double* c1)
   };
   for(int i_r_0 = 0; i_r_0 < 3; i_r_0++)
   {
-    localTensor[i_r_0][0] = 0.0;
     for(int i_g = 0; i_g < 6; i_g++)
     {
       double ST1 = 0.0;

--- a/tests/expected/op2/laplacian/model.cpp
+++ b/tests/expected/op2/laplacian/model.cpp
@@ -74,7 +74,7 @@ void A(double* localTensor, double dt, double* c0[2], int i_r_0, int i_r_1)
   };
 }
 
-void RHS(double** localTensor, double dt, double* c0[2], double* c1)
+void RHS(double** localTensor, double dt, double* c0[2], double* c1[1])
 {
   const double CG1[3][6] = { {  0.0915762135097707, 0.0915762135097707,
                                0.8168475729804585, 0.4459484909159649,
@@ -115,7 +115,7 @@ void RHS(double** localTensor, double dt, double* c0[2], double* c1)
     c_q1[i_g] = 0.0;
     for(int q_r_0 = 0; q_r_0 < 3; q_r_0++)
     {
-      c_q1[i_g] += c1[q_r_0] * CG1[q_r_0][i_g];
+      c_q1[i_g] += c1[q_r_0][0] * CG1[q_r_0][i_g];
     };
     for(int i_d_0 = 0; i_d_0 < 2; i_d_0++)
     {

--- a/tests/expected/op2/laplacian/model.cpp
+++ b/tests/expected/op2/laplacian/model.cpp
@@ -131,7 +131,6 @@ void RHS(double** localTensor, double dt, double* c0[2], double* c1)
   };
   for(int i_r_0 = 0; i_r_0 < 3; i_r_0++)
   {
-    localTensor[i_r_0][0] = 0.0;
     for(int i_g = 0; i_g < 6; i_g++)
     {
       double ST2 = 0.0;

--- a/tests/expected/op2/simple-advection-diffusion/FluidTracer.cpp
+++ b/tests/expected/op2/simple-advection-diffusion/FluidTracer.cpp
@@ -273,7 +273,6 @@ void diff_rhs(double** localTensor, double dt, double* c0[2], double* c1)
   };
   for(int i_r_0 = 0; i_r_0 < 3; i_r_0++)
   {
-    localTensor[i_r_0][0] = 0.0;
     for(int i_g = 0; i_g < 6; i_g++)
     {
       double ST7 = 0.0;
@@ -366,7 +365,6 @@ void adv_rhs(double** localTensor, double dt, double* c0[2], double* c1[2], doub
   };
   for(int i_r_0 = 0; i_r_0 < 3; i_r_0++)
   {
-    localTensor[i_r_0][0] = 0.0;
     for(int i_g = 0; i_g < 6; i_g++)
     {
       double ST8 = 0.0;

--- a/tests/expected/op2/simple-advection-diffusion/FluidTracer.cpp
+++ b/tests/expected/op2/simple-advection-diffusion/FluidTracer.cpp
@@ -207,7 +207,7 @@ void M(double* localTensor, double dt, double* c0[2], int i_r_0, int i_r_1)
   };
 }
 
-void diff_rhs(double** localTensor, double dt, double* c0[2], double* c1)
+void diff_rhs(double** localTensor, double dt, double* c0[2], double* c1[1])
 {
   const double CG1[3][6] = { {  0.0915762135097707, 0.0915762135097707,
                                0.8168475729804585, 0.4459484909159649,
@@ -260,14 +260,14 @@ void diff_rhs(double** localTensor, double dt, double* c0[2], double* c1)
     c_q1[i_g] = 0.0;
     for(int q_r_0 = 0; q_r_0 < 3; q_r_0++)
     {
-      c_q1[i_g] += c1[q_r_0] * CG1[q_r_0][i_g];
+      c_q1[i_g] += c1[q_r_0][0] * CG1[q_r_0][i_g];
     };
     for(int i_d_0 = 0; i_d_0 < 2; i_d_0++)
     {
       d_c_q1[i_g][i_d_0] = 0.0;
       for(int q_r_0 = 0; q_r_0 < 3; q_r_0++)
       {
-        d_c_q1[i_g][i_d_0] += c1[q_r_0] * d_CG1[q_r_0][i_g][i_d_0];
+        d_c_q1[i_g][i_d_0] += c1[q_r_0][0] * d_CG1[q_r_0][i_g][i_d_0];
       };
     };
   };
@@ -299,7 +299,7 @@ void diff_rhs(double** localTensor, double dt, double* c0[2], double* c1)
   };
 }
 
-void adv_rhs(double** localTensor, double dt, double* c0[2], double* c1[2], double* c2)
+void adv_rhs(double** localTensor, double dt, double* c0[2], double* c1[2], double* c2[1])
 {
   const double CG1[3][6] = { {  0.0915762135097707, 0.0915762135097707,
                                0.8168475729804585, 0.4459484909159649,
@@ -352,7 +352,7 @@ void adv_rhs(double** localTensor, double dt, double* c0[2], double* c1[2], doub
     c_q2[i_g] = 0.0;
     for(int q_r_0 = 0; q_r_0 < 3; q_r_0++)
     {
-      c_q2[i_g] += c2[q_r_0] * CG1[q_r_0][i_g];
+      c_q2[i_g] += c2[q_r_0][0] * CG1[q_r_0][i_g];
     };
     for(int i_d_0 = 0; i_d_0 < 2; i_d_0++)
     {

--- a/tests/expected/op2/swapped-advection/model.cpp
+++ b/tests/expected/op2/swapped-advection/model.cpp
@@ -4,7 +4,7 @@
 
 
 
-void rhs(double** localTensor, double dt, double* c0[2], double* c1, double* c2[2])
+void rhs(double** localTensor, double dt, double* c0[2], double* c1[1], double* c2[2])
 {
   const double CG1[3][6] = { {  0.0915762135097707, 0.0915762135097707,
                                0.8168475729804585, 0.4459484909159649,
@@ -57,7 +57,7 @@ void rhs(double** localTensor, double dt, double* c0[2], double* c1, double* c2[
     c_q1[i_g] = 0.0;
     for(int q_r_0 = 0; q_r_0 < 3; q_r_0++)
     {
-      c_q1[i_g] += c1[q_r_0] * CG1[q_r_0][i_g];
+      c_q1[i_g] += c1[q_r_0][0] * CG1[q_r_0][i_g];
     };
     for(int i_d_0 = 0; i_d_0 < 2; i_d_0++)
     {

--- a/tests/expected/op2/swapped-advection/model.cpp
+++ b/tests/expected/op2/swapped-advection/model.cpp
@@ -70,7 +70,6 @@ void rhs(double** localTensor, double dt, double* c0[2], double* c1, double* c2[
   };
   for(int i_r_0 = 0; i_r_0 < 3; i_r_0++)
   {
-    localTensor[i_r_0][0] = 0.0;
     for(int i_g = 0; i_g < 6; i_g++)
     {
       double ST0 = 0.0;


### PR DESCRIPTION
The code generation differed from the OP2 spec in two ways:
1. The local tensor was zeroed in vector assembly kernels. This should not be done.
2. Scalar coefficients were treated as pointers to scalars, when they should have been treated as pointers to arrays of length 1.

These two problems are fixed in this pull request.
