### PR TITLE
Debugging mode

### DIFF
--- a/mcfc/frontend.py
+++ b/mcfc/frontend.py
@@ -25,8 +25,7 @@
       --visualise, -v to output a visualisation of the AST
       --objvisualise  to output a deep visualisation of every ufl object
                       (warning: creates very big PDFs), implies --visualise
-      -o:<filename>   to specify the output filename
-      -p, --print     to print code to screen
+      -o:<filename>   to specify the output filename (- to print to stdout)
       -b:<backend>    to specify the backend (defaults to CUDA)"""
 
 # Python libs
@@ -48,16 +47,16 @@ def run(inputFile, opts = None):
         backend = "cuda"
 
     # Output file name
+    screen = None
     if 'o' in opts:
-        outputFileBase = os.path.splitext(opts['o'])[0]
+        # Output to stdout
+        if opts['o'] == '-':
+            screen = sys.stdout
+            outputFileBase = '.'
+        else:
+            outputFileBase = os.path.splitext(opts['o'])[0]
     else:
         outputFileBase = os.path.splitext(inputFile)[0]
-
-    # Output to stdout
-    if 'p' in opts:
-        screen = sys.stdout
-    else:
-        screen = None
 
     # PDF visualiser
     vis = False
@@ -86,7 +85,7 @@ def run(inputFile, opts = None):
 
 def _get_options():
     try: 
-        opts_list, args = getopt.getopt(sys.argv[1:], "b:hvo:p", ["visualise", "objvisualise", "print"])
+        opts_list, args = getopt.getopt(sys.argv[1:], "b:hvo:", ["visualise", "objvisualise"])
     except getopt.error, msg:
         print msg
         print __doc__

--- a/mcfc/frontend.py
+++ b/mcfc/frontend.py
@@ -26,6 +26,7 @@
       --objvisualise  to output a deep visualisation of every ufl object
                       (warning: creates very big PDFs), implies --visualise
       -o:<filename>   to specify the output filename (- to print to stdout)
+      -g, --debug     enable debugging mode (drop into pdb on error)
       -b:<backend>    to specify the backend (defaults to CUDA)"""
 
 # Python libs
@@ -40,6 +41,26 @@ def run(inputFile, opts = None):
 
     # Parse options
 
+    # Debugging mode
+    debug = False
+    if 'g' in opts or 'debug' in opts:
+        # A nicer traceback from IPython
+        # Try IPython.core.ultratb first (recommended from 0.11)
+        try:
+            from IPython.core import ultratb
+        # If that fails fall back to ultraTB (deprecated as of 0.11)
+        except ImportError:
+            try:
+                from IPython import ultraTB as ultratb
+            except ImportError:
+                print "Warning: IPython not available, not enabling debug mode."
+        else:
+            # Print a verbose backtrace and drop into pdb on error
+            # Note: will automatically choose ipdb if available
+            sys.excepthook = ultratb.FormattedTB(mode='Verbose',
+                    color_scheme='Linux', call_pdb=1)
+            debug = True
+
     # Backend
     if 'b' in opts:
         backend = opts['b']
@@ -48,15 +69,16 @@ def run(inputFile, opts = None):
 
     # Output file name
     screen = None
+    outputFileBase = os.path.splitext(inputFile)[0]
     if 'o' in opts:
         # Output to stdout
-        if opts['o'] == '-':
+        if opts['o'] == '-' and debug:
+            print "Warning: Cannot print to stdout when debugging is enabled."
+        elif opts['o'] == '-':
             screen = sys.stdout
             outputFileBase = '.'
         else:
             outputFileBase = os.path.splitext(opts['o'])[0]
-    else:
-        outputFileBase = os.path.splitext(inputFile)[0]
 
     # PDF visualiser
     vis = False
@@ -85,7 +107,8 @@ def run(inputFile, opts = None):
 
 def _get_options():
     try: 
-        opts_list, args = getopt.getopt(sys.argv[1:], "b:hvo:", ["visualise", "objvisualise"])
+        opts_list, args = getopt.getopt(sys.argv[1:], "b:ghvo:",
+            ["debug", "visualise", "objvisualise"])
     except getopt.error, msg:
         print msg
         print __doc__

--- a/mcfc/frontend.py
+++ b/mcfc/frontend.py
@@ -134,9 +134,9 @@ def main():
     run(inputFile, opts)
     return 0
 
-def testHook(inputFile, outputFile, backend = "cuda"):
+def testHook(inputFile, outputFile, debug=True, backend="cuda"):
 
-    opts = {'o': outputFile, 'b': backend}
+    opts = {'o': outputFile, 'b': backend, 'g': debug}
     run(inputFile, opts)
     return 0
 

--- a/mcfc/optionfileparser.py
+++ b/mcfc/optionfileparser.py
@@ -79,7 +79,8 @@ class OptionFileParser:
             phase = self.uflinput[key][0]
             self.uflinput[key] = ufl, self.states[phase]
 
-def testHook(inputFile, outputFile = None):
+def testHook(inputFile, outputFile=None, debug=False):
+    "debug is for compatibility with the auto test interface and ignored"
 
     # FIXME: this is an evil hack to reset coefficient numbers to 0 before
     # running the tests (necessary to make tests invariant of the order they

--- a/tests/autotest.py
+++ b/tests/autotest.py
@@ -24,14 +24,6 @@ usage: autotest.py [OPTIONS] [INPUT-FILE]
 import sys, os, shutil, getopt
 from subprocess import Popen, PIPE
 
-# A nicer traceback from IPython
-# Try IPython.core.ultratb first (recommended from 0.11)
-try:
-    from IPython.core import ultratb
-# If that fails fall back to ultraTB (deprecated as of 0.11)
-except ImportError:
-    from IPython import ultraTB as ultratb
-
 # For colouring diffs
 from pygments import highlight
 from pygments.lexers import DiffLexer
@@ -41,8 +33,6 @@ from pygments.formatters import TerminalFormatter
 from mcfc import frontend, optionfileparser
 
 def main():
-
-    sys.excepthook = ultratb.FormattedTB(mode='Context')
 
     opts, args = get_options()
     keys = opts.keys()
@@ -60,8 +50,6 @@ def main():
         print "Running in non-interactive mode."
         singleTester.interactive = False
         multiTester.interactive = False
-    else:
-        sys.excepthook = ultratb.FormattedTB(mode='Context')
     if 'replace-all' in keys or 'r' in keys:
         print "Replacing all changed expected results."
         singleTester.interactive = False

--- a/tests/autotest.py
+++ b/tests/autotest.py
@@ -116,14 +116,16 @@ def main():
         # Create the cuda outputs folder
         os.mkdir('outputs/op2', 0755)
 
-        multiTester.test(lambda infile, outfile: frontend.testHook(infile, outfile, 'op2'),
+        multiTester.test(lambda infile, outfile, debug:
+                frontend.testHook(infile, outfile, debug, 'op2'),
             lambda name: "inputs/flml/" + name + ".flml",
             lambda name: "outputs/op2/" + name,
             lambda name: "expected/op2/" + name,
             flml_sources,
             'Running form compiler tests (OP2 backend, flml input)...')
 
-        multiTester.test(lambda infile, outfile: frontend.testHook(infile, outfile, 'op2'),
+        multiTester.test(lambda infile, outfile, debug:
+                frontend.testHook(infile, outfile, debug, 'op2'),
             lambda name: "inputs/ufl/" + name + ".ufl",
             lambda name: "outputs/op2/" + name,
             lambda name: "expected/op2/" + name,
@@ -228,7 +230,7 @@ class AutoTester:
             expectedfile = self.expectfile(sourcefile)
 
             # Test hook returns 0 if successful, 1 if failed
-            hookfailed = self.testhook(inputfile, outputfile)
+            hookfailed = self.testhook(inputfile, outputfile, ~self.interactive)
 
             # Print a message if the test hook failed
             if hookfailed:


### PR DESCRIPTION
Adds parameter `-g` to the frontend to enable debugging mode: prints a verbose backtrace and drops into pdb on when an exception is raised. In the auto tester, debugging is enabled when running interactively. Also changes the `-p` parameter in favour of `-o -` for printing generated code to stdout.
